### PR TITLE
Prevent editing past events add error toasts

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -58,13 +58,14 @@
     }
   },
   "errorPage": {
-    "title": "Tjänsten stötte på ett fel",
+    "title": "The service encountered an error",
     "description": "We're sorry, but there was an error with the service. You can try again, but if the situation persists, please let us know via the feedback link at the bottom.",
     "returnToHome": "Return to homepage"
   },
   "createEvent": {
     "pageTitle": "New event",
-    "title": "New event"
+    "title": "New event",
+    "error": "Failed to save event"
   },
   "editEvent": {
     "buttons": {
@@ -72,7 +73,10 @@
       "textDirty": "There are unsaved changes on this page"
     },
     "pageTitle": "Edit event",
-    "title": "Edit event"
+    "title": "Edit event",
+    "error": "Failed to save event",
+    "errorEventIsInThePast": "Event is in the past",
+    "errorEventIsInThePastDescription": "Event that is in the past can't be edited."
   },
   "eventDetails": {
     "basicInfo": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -64,7 +64,8 @@
   },
   "createEvent": {
     "pageTitle": "Uusi tapahtuma",
-    "title": "Uusi tapahtuma"
+    "title": "Uusi tapahtuma",
+    "error": "Tapahtuma tallentaminen epäonnistui"
   },
   "editEvent": {
     "buttons": {
@@ -72,7 +73,10 @@
       "textDirty": "Sivulla on tallentamattomia muutoksia"
     },
     "pageTitle": "Muokkaa tapahtumaa",
-    "title": "Muokkaa tapahtumaa"
+    "title": "Muokkaa tapahtumaa",
+    "error": "Tapahtuma tallentaminen epäonnistui",
+    "errorEventIsInThePast": "Tapahtuma on menneisyydessä",
+    "errorEventIsInThePastDescription": "Menneisyydessä olevaa tapahtumaa ei voi enää muokata."
   },
   "eventDetails": {
     "basicInfo": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -65,7 +65,7 @@
   "createEvent": {
     "pageTitle": "Uusi tapahtuma",
     "title": "Uusi tapahtuma",
-    "error": "Tapahtuma tallentaminen epäonnistui"
+    "error": "Tapahtuman tallentaminen epäonnistui"
   },
   "editEvent": {
     "buttons": {
@@ -74,7 +74,7 @@
     },
     "pageTitle": "Muokkaa tapahtumaa",
     "title": "Muokkaa tapahtumaa",
-    "error": "Tapahtuma tallentaminen epäonnistui",
+    "error": "Tapahtuman tallentaminen epäonnistui",
     "errorEventIsInThePast": "Tapahtuma on menneisyydessä",
     "errorEventIsInThePastDescription": "Menneisyydessä olevaa tapahtumaa ei voi enää muokata."
   },

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -63,7 +63,8 @@
   },
   "createEvent": {
     "pageTitle": "Ny evenemang",
-    "title": "Ny evenemang"
+    "title": "Ny evenemang",
+    "error": "Det gick inte att spara händelsen"
   },
   "editEvent": {
     "buttons": {
@@ -71,7 +72,10 @@
       "textDirty": "Det finns inte sparade ändringar på den här sidan"
     },
     "pageTitle": "Redigera evenemang",
-    "title": "Redigera evenemang"
+    "title": "Redigera evenemang",
+    "error": "Det gick inte att spara händelsen",
+    "errorEventIsInThePast": "Händelsen är i det förflutna",
+    "errorEventIsInThePastDescription": "Händelse som är tidigare kan inte redigeras."
   },
   "eventDetails": {
     "basicInfo": {

--- a/src/domain/event/CreateEventPage.tsx
+++ b/src/domain/event/CreateEventPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
+import { toast } from 'react-toastify';
 
 import {
   useCreateEventMutation,
@@ -67,7 +68,10 @@ const CreateEventPage: React.FC = () => {
         search: `?language=${selectedLanguage}`,
       });
     } catch (e) {
-      // Check apolloClient to see error handling
+      // TODO: Improve error handling when API returns more informative errors
+      toast(t('createEvent.error'), {
+        type: toast.TYPE.ERROR,
+      });
     }
   };
   return (

--- a/src/domain/event/EditEventPage.tsx
+++ b/src/domain/event/EditEventPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation, useParams } from 'react-router';
+import { toast } from 'react-toastify';
 
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
 import {
@@ -24,6 +25,8 @@ import {
   getEventLanguageFromUrl,
   getEventPayload,
   getFirstAvailableLanguage,
+  isEditableEvent,
+  isPastEvent,
 } from './utils';
 
 const EditEventPage: React.FC = () => {
@@ -116,7 +119,10 @@ const EditEventPage: React.FC = () => {
         search: `?language=${selectedLanguage}`,
       });
     } catch (e) {
-      // Check apolloClient to see error handling
+      // TODO: Improve error handling when API returns more informative errors
+      toast(t('editEvent.error'), {
+        type: toast.TYPE.ERROR,
+      });
     }
   };
 
@@ -155,8 +161,8 @@ const EditEventPage: React.FC = () => {
   return (
     <PageWrapper title="editEvent.pageTitle">
       <LoadingSpinner isLoading={loading}>
-        <Container>
-          {eventData ? (
+        {isEditableEvent(eventData) ? (
+          <Container>
             <div className={styles.eventPage}>
               <EventForm
                 eventData={eventData}
@@ -167,10 +173,15 @@ const EditEventPage: React.FC = () => {
                 title={t('editEvent.title')}
               />
             </div>
-          ) : (
-            <ErrorPage />
-          )}
-        </Container>
+          </Container>
+        ) : isPastEvent(eventData) ? (
+          <ErrorPage
+            title={t('editEvent.errorEventIsInThePast')}
+            description={t('editEvent.errorEventIsInThePastDescription')}
+          />
+        ) : (
+          <ErrorPage />
+        )}
       </LoadingSpinner>
     </PageWrapper>
   );

--- a/src/domain/event/eventDetailsButtons/EventDetailsButtons.tsx
+++ b/src/domain/event/eventDetailsButtons/EventDetailsButtons.tsx
@@ -1,4 +1,3 @@
-import isFutureDate from 'date-fns/isFuture';
 import { Button } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -11,6 +10,7 @@ import useLocale from '../../../hooks/useLocale';
 import { Language } from '../../../types';
 import { ROUTES } from '../../app/routes/constants';
 import EventLanguageSelector from '../eventLanguageSelector/EventLanguageSelector';
+import { isFutureEvent } from '../utils';
 import styles from './eventDetailsButtons.module.scss';
 
 interface Props {
@@ -28,11 +28,6 @@ const EventDetailsButtons: React.FC<Props> = ({
   const locale = useLocale();
   const history = useHistory();
   const eventId = eventData.event?.id || '';
-
-  const isFutureEvent = () =>
-    eventData?.event?.startTime
-      ? isFutureDate(new Date(eventData?.event?.startTime))
-      : false;
 
   const goToEventList = () => {
     history.push(ROUTES.HOME);
@@ -62,7 +57,7 @@ const EventDetailsButtons: React.FC<Props> = ({
         onClick={onClickLanguage}
         selectedLanguage={selectedLanguage}
       />
-      {isFutureEvent() && (
+      {isFutureEvent(eventData) && (
         <div>
           <Button onClick={goToEditPage}>
             {t('eventDetails.buttons.buttonEdit')}

--- a/src/domain/event/eventDetailsButtons/EventDetailsButtons.tsx
+++ b/src/domain/event/eventDetailsButtons/EventDetailsButtons.tsx
@@ -1,3 +1,4 @@
+import isFutureDate from 'date-fns/isFuture';
 import { Button } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -28,6 +29,11 @@ const EventDetailsButtons: React.FC<Props> = ({
   const history = useHistory();
   const eventId = eventData.event?.id || '';
 
+  const isFutureEvent = () =>
+    eventData?.event?.startTime
+      ? isFutureDate(new Date(eventData?.event?.startTime))
+      : false;
+
   const goToEventList = () => {
     history.push(ROUTES.HOME);
   };
@@ -56,11 +62,13 @@ const EventDetailsButtons: React.FC<Props> = ({
         onClick={onClickLanguage}
         selectedLanguage={selectedLanguage}
       />
-      <div>
-        <Button onClick={goToEditPage}>
-          {t('eventDetails.buttons.buttonEdit')}
-        </Button>
-      </div>
+      {isFutureEvent() && (
+        <div>
+          <Button onClick={goToEditPage}>
+            {t('eventDetails.buttons.buttonEdit')}
+          </Button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -1,3 +1,6 @@
+import isFutureDate from 'date-fns/isFuture';
+import isPastDate from 'date-fns/isPast';
+
 import { LINKEDEVENTS_CONTENT_TYPE, SUPPORT_LANGUAGES } from '../../constants';
 import { EventQuery } from '../../generated/graphql';
 import { Language } from '../../types';
@@ -115,3 +118,16 @@ export const getEventPayload = (
     },
   };
 };
+
+export const isPastEvent = (eventData: EventQuery | undefined) =>
+  eventData?.event?.startTime
+    ? isPastDate(new Date(eventData?.event?.startTime))
+    : false;
+
+export const isFutureEvent = (eventData: EventQuery | undefined) =>
+  eventData?.event?.startTime
+    ? isFutureDate(new Date(eventData?.event?.startTime))
+    : false;
+
+export const isEditableEvent = (eventData: EventQuery | undefined) =>
+  isFutureEvent(eventData);


### PR DESCRIPTION
## Description

- Show error page when trying to edit past event

- Hide edit event button when event is in the past

- Show error messages on edit event and create event pages

## Issues
### Closes
**[PT-232](https://helsinkisolutionoffice.atlassian.net/browse/PT-232):** 