### PR TITLE
PT-409 | Add image file size description to create event page

### DIFF
--- a/src/common/components/imageInput/ImageInput.tsx
+++ b/src/common/components/imageInput/ImageInput.tsx
@@ -1,9 +1,13 @@
 import { Button } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
 
 import { useUploadSingleImageMutation } from '../../../generated/graphql';
 import InputWrapper, { InputWrapperProps } from '../textInput/InputWrapper';
+
+// 2 megabytes
+const IMAGE_MAX_SIZE = 2097152;
 
 type ImageInputProps = {
   setFieldValue: (
@@ -27,14 +31,29 @@ const ImageInput: React.FC<ImageInputProps> = ({
     inputRef.current?.click();
   };
 
+  const resetImageInput = () => {
+    if (inputRef.current?.value) {
+      inputRef.current.value = '';
+    }
+  };
+
   const handleImageFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.currentTarget.files?.[0]) {
+    const file = e.currentTarget.files?.[0];
+    const fileSize = file?.size;
+
+    if (fileSize && fileSize > IMAGE_MAX_SIZE) {
+      toast(t('form.error.imageTooBig'), { type: toast.TYPE.ERROR });
+      resetImageInput();
+      return;
+    }
+
+    if (file) {
       try {
         const data = await uploadImage({
           variables: {
             image: {
               name: '',
-              image: e.currentTarget.files[0],
+              image: file,
             },
           },
         });

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -257,7 +257,7 @@
     "basicInfo": {
       "addImage": "Add image",
       "deleteImage": "Delete image",
-      "descriptionAddImage": "Add image for the event. You also need name of the photographer and publication license",
+      "descriptionAddImage": "Add image for the event. You also need name of the photographer and publication license. Max size of the image is 2 megabytes. Recommended dimensios are 1200px X 800px.",
       "imageAltTextHelp": "Description of the contents of the image. Add license information also.",
       "labelDescription": "Description",
       "labelDuration": "Event duration, min",
@@ -303,8 +303,7 @@
       "labelLocation": "Default venue",
       "placeholderLocation": "Search place...",
       "title": "Location"
-    },
-    "title": "Event details"
+    }
   },
   "events": {
     "buttonLoadMore": "Show more",
@@ -396,6 +395,9 @@
       "buttonEdit": "Change",
       "labelReittiopas": "Reittiopas:",
       "labelServicemap": "Servicemap:"
+    },
+    "error": {
+      "imageTooBig": "Image is too big. Maximum size of the image is 2 megabytes."
     }
   },
   "footer": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -258,7 +258,7 @@
     "basicInfo": {
       "addImage": "Lisää kuva",
       "deleteImage": "Poista kuva",
-      "descriptionAddImage": "Lisää tapahtumalle kuva. Tarvitset myös kuvaajan nimen ja julkaisulisenssin",
+      "descriptionAddImage": "Lisää tapahtumalle kuva. Tarvitset myös kuvaajan nimen ja julkaisulisenssin. Maksimi koko 2 megatavua. Suositeltu kuvakoko on 1200px X 800px.",
       "imageAltTextHelp": "Kuvan sisällön sanallinen kuvaus. Lisää kuvan loppuun myös lisenssitieto.",
       "labelDescription": "Kuvaus",
       "labelDuration": "Tapahtuman kesto, min",
@@ -396,6 +396,9 @@
       "buttonEdit": "Vaihda",
       "labelReittiopas": "Reittiopas:",
       "labelServicemap": "Palvelukartta:"
+    },
+    "error": {
+      "imageTooBig": "Kuva on liian iso. Kuvan maksimikoko on 2 megatavua."
     }
   },
   "footer": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -258,7 +258,7 @@
     "basicInfo": {
       "addImage": "Lägg till bild",
       "deleteImage": "Ta bort bild",
-      "descriptionAddImage": "Lägg till bild för händelsen. Du behöver också namnet på fotografen och publiceringslicensen",
+      "descriptionAddImage": "Lägg till bild för händelsen. Du behöver också namnet på fotografen och publiceringslicensen. Bildens maximala storlek är 2 megabyte. Rekommenderade dimensios är 1200px X 800px.",
       "imageAltTextHelp": "Beskrivning av innehållet i bilden. Lägg till licensinformation också.",
       "labelDescription": "Beskrivning",
       "labelDuration": "Evenemang varaktighet, min",
@@ -397,6 +397,9 @@
       "buttonEdit": "Förändra",
       "labelReittiopas": "Reittiopas:",
       "labelServicemap": "Servicekartan:"
+    },
+    "error": {
+      "imageTooBig": "Bilden är för stor. Bildens maximala storlek är 2 megabyte."
     }
   },
   "footer": {


### PR DESCRIPTION
## Description

- Add image size description to image input

- Handle too big file size with error message

## Issues
### Closes
**[PT-409](https://helsinkisolutionoffice.atlassian.net/browse/PT-409):** 

## Screenshots

<img width="1912" alt="Screenshot 2020-09-21 at 14 52 14" src="https://user-images.githubusercontent.com/15219142/93763437-1df27680-fc1a-11ea-938e-e3f25884f5b1.png">
<img width="900" alt="Screenshot 2020-09-21 at 14 52 03" src="https://user-images.githubusercontent.com/15219142/93763439-1e8b0d00-fc1a-11ea-9967-e69c06388044.png">