### PR TITLE
PT-475 | Separate queries for different event categories

### DIFF
--- a/src/domain/events/EventsPage.tsx
+++ b/src/domain/events/EventsPage.tsx
@@ -46,11 +46,11 @@ const EventsPage: React.FC = () => {
   };
 
   const {
-    data: eventsData,
-    loading: loadingEvents,
-    isLoadingMore: isLoadingMoreEvents,
-    hasNextPage: eventsHasNextPage,
-    fetchMore: fetchMoreEvents,
+    data: upcomingEventsData,
+    loading: loadingUpcomingEvents,
+    isLoadingMore: isLoadingMoreUpcomingEvents,
+    hasNextPage: upcomingEventsHasNextPage,
+    fetchMore: fetchMoreUpcomingEvents,
   } = useEventsQueryHelper({
     errorPolicy: 'ignore',
     variables: {
@@ -62,6 +62,7 @@ const EventsPage: React.FC = () => {
 
   const {
     data: eventsWithoutOccurrencesData,
+    loading: loadingEventsWithoutOccurrences,
     isLoadingMore: loadingMoreEventsWithoutOccurrences,
     fetchMore: fetchMoreEventsWithoutOccurrences,
     hasNextPage: eventsWithoutOccurrencesHasNextPage,
@@ -76,6 +77,7 @@ const EventsPage: React.FC = () => {
 
   const {
     data: pastEventsData,
+    loading: loadingPastEvents,
     isLoadingMore: loadingMorePastEvents,
     fetchMore: fetchMorePastEvents,
     hasNextPage: pastEventsHasNextPage,
@@ -96,8 +98,9 @@ const EventsPage: React.FC = () => {
     history.push(`/${locale}${ROUTES.OCCURRENCES.replace(':id', id)}`);
   };
 
-  const eventsWithComingOccurrences = eventsData?.events?.data || [];
-  const eventsWithComingOccurrencesCount = eventsData?.events?.meta.count;
+  const eventsWithComingOccurrences = upcomingEventsData?.events?.data || [];
+  const eventsWithComingOccurrencesCount =
+    upcomingEventsData?.events?.meta.count;
 
   const eventsWithoutOccurrences =
     eventsWithoutOccurrencesData?.events?.data || [];
@@ -111,6 +114,11 @@ const EventsPage: React.FC = () => {
     setInputValue(e.target.value);
   };
 
+  const loadingEvents =
+    loadingUpcomingEvents ||
+    loadingEventsWithoutOccurrences ||
+    loadingPastEvents;
+
   return (
     <PageWrapper>
       <Container>
@@ -118,13 +126,7 @@ const EventsPage: React.FC = () => {
           <ActiveOrganisationInfo as="h1" />
 
           <div className={styles.comingEventsTitleWrapper}>
-            <EventsTitle
-              count={
-                eventsWithComingOccurrencesCount ||
-                eventsWithComingOccurrences.length
-              }
-              title={t('events.titleComingEvents')}
-            />
+            <div />
             <div className={styles.searchWrapper}>
               <div>
                 <Button fullWidth={true} onClick={goToCreateEventPage}>
@@ -142,71 +144,98 @@ const EventsPage: React.FC = () => {
             </div>
           </div>
           <LoadingSpinner isLoading={loadingEvents}>
-            {!!eventsWithComingOccurrences.length ? (
-              <>
-                <Events
-                  events={eventsWithComingOccurrences}
-                  goToEventOccurrencesPage={goToEventOccurrencesPage}
-                />
-                {eventsHasNextPage && (
-                  <ShowMoreButton
-                    loading={isLoadingMoreEvents}
-                    onClick={fetchMoreEvents}
-                  />
-                )}
-              </>
-            ) : (
-              <p>{t('events.textNoComingEvents')}</p>
-            )}
-
-            {!!eventsWithoutOccurrences.length && (
-              <>
-                <EventsTitle
-                  count={
-                    eventsWithoutOccurrencesCount ||
-                    eventsWithoutOccurrences.length
-                  }
-                  title={t('events.titleEventsWithoutOccurrences')}
-                />
-                <Events
-                  events={eventsWithoutOccurrences}
-                  goToEventOccurrencesPage={goToEventOccurrencesPage}
-                />
-                {eventsWithoutOccurrencesHasNextPage && (
-                  <ShowMoreButton
-                    loading={loadingMoreEventsWithoutOccurrences}
-                    onClick={fetchMoreEventsWithoutOccurrences}
-                  />
-                )}
-              </>
-            )}
-
-            {!!eventsWithPastOccurrences.length && (
-              <>
-                <EventsTitle
-                  count={
-                    eventsWithPastOccurrencesCount ||
-                    eventsWithPastOccurrences.length
-                  }
-                  title={t('events.titleEventsWithPastOccurrences')}
-                />
-                <Events
-                  events={eventsWithPastOccurrences}
-                  goToEventOccurrencesPage={goToEventOccurrencesPage}
-                />
-                {pastEventsHasNextPage && (
-                  <ShowMoreButton
-                    loading={loadingMorePastEvents}
-                    onClick={fetchMorePastEvents}
-                  />
-                )}
-              </>
-            )}
+            <EventsCategoryList
+              eventsCount={
+                eventsWithComingOccurrencesCount ||
+                eventsWithComingOccurrences.length
+              }
+              title={t('events.titleComingEvents')}
+              events={eventsWithComingOccurrences}
+              onGoToEventOccurrencesPage={goToEventOccurrencesPage}
+              isLoadingMoreEvents={isLoadingMoreUpcomingEvents}
+              onFetchMoreEvents={fetchMoreUpcomingEvents}
+              hasNextPage={upcomingEventsHasNextPage}
+              notFoundText={t('events.textNoComingEvents')}
+            />
+            <EventsCategoryList
+              eventsCount={
+                eventsWithoutOccurrencesCount || eventsWithoutOccurrences.length
+              }
+              title={t('events.titleEventsWithoutOccurrences')}
+              events={eventsWithoutOccurrences}
+              onGoToEventOccurrencesPage={goToEventOccurrencesPage}
+              isLoadingMoreEvents={loadingMoreEventsWithoutOccurrences}
+              onFetchMoreEvents={fetchMoreEventsWithoutOccurrences}
+              hasNextPage={eventsWithoutOccurrencesHasNextPage}
+            />
+            <EventsCategoryList
+              eventsCount={
+                eventsWithPastOccurrencesCount ||
+                eventsWithPastOccurrences.length
+              }
+              title={t('events.titleEventsWithPastOccurrences')}
+              events={eventsWithPastOccurrences}
+              onGoToEventOccurrencesPage={goToEventOccurrencesPage}
+              isLoadingMoreEvents={loadingMorePastEvents}
+              onFetchMoreEvents={fetchMorePastEvents}
+              hasNextPage={pastEventsHasNextPage}
+            />
           </LoadingSpinner>
         </div>
       </Container>
     </PageWrapper>
   );
+};
+
+interface EventsCategoryListProps {
+  eventsCount: number;
+  title: string;
+  events: EventFieldsFragment[];
+  onGoToEventOccurrencesPage: (id: string) => void;
+  isLoadingMoreEvents: boolean;
+  onFetchMoreEvents: () => Promise<void>;
+  hasNextPage: boolean;
+  notFoundText?: string;
+}
+
+const EventsCategoryList: React.FC<EventsCategoryListProps> = ({
+  eventsCount,
+  title,
+  events,
+  onGoToEventOccurrencesPage,
+  isLoadingMoreEvents,
+  onFetchMoreEvents,
+  hasNextPage,
+  notFoundText,
+}) => {
+  if (!!events.length) {
+    return (
+      <>
+        <EventsTitle count={eventsCount} title={title} />
+        <Events
+          events={events}
+          goToEventOccurrencesPage={onGoToEventOccurrencesPage}
+        />
+        {hasNextPage && (
+          <ShowMoreButton
+            loading={isLoadingMoreEvents}
+            onClick={onFetchMoreEvents}
+          />
+        )}
+      </>
+    );
+  }
+
+  if (notFoundText) {
+    return (
+      <>
+        <EventsTitle count={eventsCount} title={title} />
+        <p>{notFoundText}</p>
+      </>
+    );
+  }
+
+  return null;
 };
 
 const EventsTitle: React.FC<{ count: number; title: string }> = ({

--- a/src/domain/events/constants.ts
+++ b/src/domain/events/constants.ts
@@ -1,4 +1,4 @@
-export const PAGE_SIZE = 10;
+export const PAGE_SIZE = 5;
 
 export enum EVENT_SORT_KEYS {
   DURATION = 'duration',

--- a/src/domain/events/query.ts
+++ b/src/domain/events/query.ts
@@ -26,6 +26,7 @@ export const QUERY_EVENT = gql`
     $text: String
     $translation: String
     $showAll: Boolean
+    $publicationStatus: String
   ) {
     events(
       divisions: $divisions
@@ -47,6 +48,7 @@ export const QUERY_EVENT = gql`
       text: $text
       translation: $translation
       showAll: $showAll
+      publicationStatus: $publicationStatus
     ) {
       meta {
         ...metaFields

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -1,0 +1,56 @@
+import { QueryHookOptions } from '@apollo/react-hooks';
+import React from 'react';
+
+import {
+  EventsQuery,
+  EventsQueryVariables,
+  useEventsQuery,
+} from '../../generated/graphql';
+import getPageNumberFromUrl from '../../utils/getPageNumberFromUrl';
+
+export const useEventsQueryHelper = ({
+  variables,
+}: QueryHookOptions<EventsQuery, EventsQueryVariables>) => {
+  const [isLoadingMore, setIsLoadingMore] = React.useState(false);
+
+  const { fetchMore: fetchMoreEvents, data, ...helpers } = useEventsQuery({
+    errorPolicy: 'ignore',
+    variables: variables,
+  });
+
+  const nextPage = React.useMemo(() => {
+    const nextUrl = data?.events?.meta.next;
+    return nextUrl ? getPageNumberFromUrl(nextUrl) : null;
+  }, [data]);
+
+  const hasNextPage = Boolean(nextPage);
+
+  const fetchMore = async () => {
+    if (nextPage) {
+      try {
+        setIsLoadingMore(true);
+        await fetchMoreEvents({
+          updateQuery: (prev: EventsQuery, { fetchMoreResult }) => {
+            if (!fetchMoreResult?.events) {
+              return prev;
+            }
+
+            const prevEvents = prev.events?.data || [];
+            const newEvents = fetchMoreResult.events?.data || [];
+            fetchMoreResult.events.data = [...prevEvents, ...newEvents];
+
+            return fetchMoreResult;
+          },
+          variables: {
+            page: nextPage,
+          },
+        });
+        setIsLoadingMore(false);
+      } catch (e) {
+        setIsLoadingMore(false);
+      }
+    }
+  };
+
+  return { data, fetchMore, isLoadingMore, hasNextPage, ...helpers };
+};

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -2088,6 +2088,7 @@ export type EventsQueryVariables = {
   text?: Maybe<Scalars['String']>;
   translation?: Maybe<Scalars['String']>;
   showAll?: Maybe<Scalars['Boolean']>;
+  publicationStatus?: Maybe<Scalars['String']>;
 };
 
 
@@ -3560,8 +3561,8 @@ export type EventQueryHookResult = ReturnType<typeof useEventQuery>;
 export type EventLazyQueryHookResult = ReturnType<typeof useEventLazyQuery>;
 export type EventQueryResult = ApolloReactCommon.QueryResult<EventQuery, EventQueryVariables>;
 export const EventsDocument = gql`
-    query Events($divisions: [String], $end: String, $include: [String], $inLanguage: String, $isFree: Boolean, $keywords: [String], $keywordNot: [String], $language: String, $location: String, $page: Int, $pageSize: Int, $publisher: ID, $sort: String, $start: String, $superEvent: ID, $superEventType: [String], $text: String, $translation: String, $showAll: Boolean) {
-  events(divisions: $divisions, end: $end, include: $include, inLanguage: $inLanguage, isFree: $isFree, keywords: $keywords, keywordNot: $keywordNot, language: $language, location: $location, page: $page, pageSize: $pageSize, publisher: $publisher, sort: $sort, start: $start, superEvent: $superEvent, superEventType: $superEventType, text: $text, translation: $translation, showAll: $showAll) {
+    query Events($divisions: [String], $end: String, $include: [String], $inLanguage: String, $isFree: Boolean, $keywords: [String], $keywordNot: [String], $language: String, $location: String, $page: Int, $pageSize: Int, $publisher: ID, $sort: String, $start: String, $superEvent: ID, $superEventType: [String], $text: String, $translation: String, $showAll: Boolean, $publicationStatus: String) {
+  events(divisions: $divisions, end: $end, include: $include, inLanguage: $inLanguage, isFree: $isFree, keywords: $keywords, keywordNot: $keywordNot, language: $language, location: $location, page: $page, pageSize: $pageSize, publisher: $publisher, sort: $sort, start: $start, superEvent: $superEvent, superEventType: $superEventType, text: $text, translation: $translation, showAll: $showAll, publicationStatus: $publicationStatus) {
     meta {
       ...metaFields
     }
@@ -3617,6 +3618,7 @@ export function withEvents<TProps, TChildProps = {}, TDataName extends string = 
  *      text: // value for 'text'
  *      translation: // value for 'translation'
  *      showAll: // value for 'showAll'
+ *      publicationStatus: // value for 'publicationStatus'
  *   },
  * });
  */


### PR DESCRIPTION
## Description

- Have separate load more buttons in events page and different queries for each category

## Issues
### Closes
**[PT-475](https://helsinkisolutionoffice.atlassian.net/browse/PT-475):** 

## Screenshots

<img width="356" alt="Screenshot 2020-09-22 at 12 42 36" src="https://user-images.githubusercontent.com/15219142/93870877-83a43880-fcd6-11ea-9781-074fa68b1da7.png">
