### PR TITLE
Use flex-wrap to fix overflowing content

### DIFF
--- a/src/domain/event/eventKeywords/eventKeywords.module.scss
+++ b/src/domain/event/eventKeywords/eventKeywords.module.scss
@@ -1,5 +1,6 @@
 .eventKeywords {
   display: inline-flex;
+  flex-wrap: wrap;
 }
 
 .keyword {


### PR DESCRIPTION
Ticket: https://helsinkisolutionoffice.atlassian.net/browse/PT-631

Before:
<img width="650" alt="Screenshot 2020-11-26 at 10 49 24 AM" src="https://user-images.githubusercontent.com/7648194/100359387-21322600-3000-11eb-8915-65f24e4ac96f.png">

After:
<img width="650" alt="Screenshot 2020-11-26 at 3 53 54 PM" src="https://user-images.githubusercontent.com/7648194/100359475-44f56c00-3000-11eb-8417-e4045f8f7638.png">
