### PR TITLE
PT-632 fix: Event starting day cannot be the current day

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,4 +2,4 @@ REACT_APP_API_URI=https://palvelutarjotin-api.test.kuva.hel.ninja/graphql
 
 REACT_APP_LINKEDEVENTS_API_URI=https://api.hel.fi/linkedevents-test/v1
 
-REACT_APP_OIDC_AUTHORITY="https://tunnistamo.test.kuva.hel.ninja"
+REACT_APP_OIDC_AUTHORITY=https://tunnistamo.test.kuva.hel.ninja

--- a/src/common/components/datepicker/Datepicker.tsx
+++ b/src/common/components/datepicker/Datepicker.tsx
@@ -291,6 +291,7 @@ const Datepicker: React.FC<DatepickerProps> = ({
   });
 
   const { month, year } = activeMonth;
+  const helperDescription = invalidText || helperText;
 
   return (
     <DatepickerContext.Provider
@@ -320,7 +321,7 @@ const Datepicker: React.FC<DatepickerProps> = ({
         <InputWrapper
           className={className}
           id={id}
-          helperText={invalidText || helperText}
+          helperText={helperDescription}
           invalid={!!invalidText}
           labelText={labelText}
           hideLabel={hideLabel}
@@ -335,6 +336,7 @@ const Datepicker: React.FC<DatepickerProps> = ({
               [styles.invalid]: !!invalidText,
             })}
             aria-invalid={!!invalidText}
+            aria-describedby={helperDescription && `${id}-helper`}
             onChange={handleInputChange}
             onFocus={handleInputFocus}
             onBlur={handleInputBlur}

--- a/src/common/components/datepicker/Datepicker.tsx
+++ b/src/common/components/datepicker/Datepicker.tsx
@@ -334,6 +334,7 @@ const Datepicker: React.FC<DatepickerProps> = ({
             className={classNames(inputStyles.input, styles.datepickerInput, {
               [styles.invalid]: !!invalidText,
             })}
+            aria-invalid={!!invalidText}
             onChange={handleInputChange}
             onFocus={handleInputFocus}
             onBlur={handleInputBlur}

--- a/src/common/components/textInput/InputWrapper.tsx
+++ b/src/common/components/textInput/InputWrapper.tsx
@@ -77,7 +77,7 @@ const InputWrapper: FC<InputWrapperProps> = React.forwardRef<
       )}
       <div className={classNames(styles.inputWrapper)}>{children}</div>
       {helperText && (
-        <div className={styles.helperText} id={`${id}-helper`}>
+        <div className={styles.helperText} id={`${id}-helper`} role="alert">
           {helperText}
         </div>
       )}

--- a/src/common/components/textInput/InputWrapper.tsx
+++ b/src/common/components/textInput/InputWrapper.tsx
@@ -76,7 +76,11 @@ const InputWrapper: FC<InputWrapperProps> = React.forwardRef<
         </Tooltip>
       )}
       <div className={classNames(styles.inputWrapper)}>{children}</div>
-      {helperText && <div className={styles.helperText}>{helperText}</div>}
+      {helperText && (
+        <div className={styles.helperText} role="alert">
+          {helperText}
+        </div>
+      )}
     </div>
   )
 );

--- a/src/common/components/textInput/InputWrapper.tsx
+++ b/src/common/components/textInput/InputWrapper.tsx
@@ -77,7 +77,7 @@ const InputWrapper: FC<InputWrapperProps> = React.forwardRef<
       )}
       <div className={classNames(styles.inputWrapper)}>{children}</div>
       {helperText && (
-        <div className={styles.helperText} role="alert">
+        <div className={styles.helperText} id={`${id}-helper`}>
           {helperText}
         </div>
       )}

--- a/src/domain/app/i18n/constants.ts
+++ b/src/domain/app/i18n/constants.ts
@@ -9,7 +9,7 @@ export enum VALIDATION_MESSAGE_KEYS {
   URL = 'form.validation.string.url',
   DATE_REQUIRED = 'form.validation.date.required',
   DATE = 'form.validation.string.date',
-  DATE_FUTURE = 'form.validation.date.future',
+  DATE_TODAY_OR_LATER = 'form.validation.date.mustNotInThePast',
   DATE_MIN = 'form.validation.date.min',
   DATE_MAX = 'form.validation.date.max',
   TIME = 'form.validation.string.time',

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -292,7 +292,7 @@
     "buttonSaveDraft": "Save draft",
     "occurrenceTime": {
       "titleOccurrenceTime": "Occurrence time",
-      "occurrenceTimeHelperText": "First occurrence date. Rest of the occurrences and additional information are entererd in step 2."
+      "occurrenceTimeHelperText": "First occurrence date. Rest of the occurrences and additional information are entered in step 2."
     },
     "categorisation": {
       "helperKeywords": "Enter a keyword and select from the suggested options",
@@ -432,7 +432,7 @@
       },
       "date": {
         "required": "This field is required",
-        "future": "This date must be in the future",
+        "mustNotInThePast": "This date must not be in the past",
         "min": "This date must be after {{min}}",
         "max": "This date must be before {{max}}"
       },

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -432,10 +432,10 @@
         "time": "Ajan tulee olla muotoa hh:mm"
       },
       "date": {
-        "required": "Tämä kenttä on pakollinen",
-        "future": "Tämän kentän on oltava tulevaisuudessa",
-        "min": "Tämän kentän on oltava {{min}} jälkeen",
-        "max": "Tämän kentän on oltava ennen {{max}}"
+        "required": "Päivämäärä on pakollinen",
+        "mustNotInThePast": "Päivämäärä ei voi olla menneisyydessä",
+        "min": "Päivämäärän on oltava {{min}} jälkeen",
+        "max": "Päivämäärän on oltava ennen {{max}}"
       },
       "time": {
         "required": "Tämä kenttä on pakollinen",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -435,7 +435,7 @@
       },
       "date": {
         "required": "Detta fält krävs",
-        "future": "Detta datum måste vara i framtiden",
+        "mustNotInThePast": "Detta datum kan inte vara i förr",
         "min": "Detta datum måste vara efter {{min}}",
         "max": "Detta datum måste vara före {{max}}"
       },

--- a/src/domain/event/eventForm/ValidationSchema.ts
+++ b/src/domain/event/eventForm/ValidationSchema.ts
@@ -1,8 +1,8 @@
 import isBefore from 'date-fns/isBefore';
-import isFuture from 'date-fns/isFuture';
 import parseDate from 'date-fns/parse';
 import * as Yup from 'yup';
 
+import { isTodayOrLater } from '../../../utils/dateUtils';
 import { VALIDATION_MESSAGE_KEYS } from '../../app/i18n/constants';
 import { isValidTime } from '../../occurrence/eventOccurrenceForm/ValidationSchema';
 
@@ -35,9 +35,9 @@ const createValidationSchemaYup = (
       .typeError(VALIDATION_MESSAGE_KEYS.DATE)
       .required(VALIDATION_MESSAGE_KEYS.DATE_REQUIRED)
       .test(
-        'isInTheFuture',
-        VALIDATION_MESSAGE_KEYS.DATE_FUTURE,
-        (value: Date) => isFuture(value)
+        'isTodayOrInTheFuture',
+        VALIDATION_MESSAGE_KEYS.DATE_TODAY_OR_LATER,
+        isTodayOrLater
       ),
     neededOccurrences: Yup.number()
       .required(VALIDATION_MESSAGE_KEYS.NUMBER_REQUIRED)
@@ -76,8 +76,10 @@ export const createEventSchema = {
   occurrenceDate: Yup.date()
     .typeError(VALIDATION_MESSAGE_KEYS.DATE)
     .required(VALIDATION_MESSAGE_KEYS.DATE_REQUIRED)
-    .test('isInTheFuture', VALIDATION_MESSAGE_KEYS.DATE_FUTURE, (value: Date) =>
-      isFuture(value)
+    .test(
+      'isTodayOrInTheFuture',
+      VALIDATION_MESSAGE_KEYS.DATE_TODAY_OR_LATER,
+      isTodayOrLater
     ),
   occurrenceStartsAt: Yup.string()
     .required(VALIDATION_MESSAGE_KEYS.TIME_REQUIRED)

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -1,5 +1,4 @@
 import { MockedResponse } from '@apollo/react-testing';
-import { fireEvent } from '@testing-library/react';
 import { addDays, format, formatISO } from 'date-fns';
 import { advanceTo, clear } from 'jest-date-mock';
 import range from 'lodash/range';
@@ -25,10 +24,12 @@ import {
   fakeVenue,
 } from '../../../utils/mockDataUtils';
 import {
+  fireEvent,
   renderWithRoute,
   screen,
   userEvent,
   waitFor,
+  waitForElementToBeRemoved,
 } from '../../../utils/testUtils';
 import apolloClient from '../../app/apollo/apolloClient';
 import messages from '../../app/i18n/fi.json';
@@ -368,10 +369,11 @@ test('yesterday is not valid event start day', async () => {
   fireEvent.blur(dateInput);
   await waitFor(() => {
     expect(dateInput).toBeInvalid();
+    expect(dateInput).toHaveAttribute('aria-describedby');
+    expect(
+      screen.queryByText(messages.form.validation.date.mustNotInThePast)
+    ).toBeInTheDocument();
   });
-  expect(screen.getByRole('alert')).toHaveTextContent(
-    messages.form.validation.date.mustNotInThePast
-  );
 });
 
 test('today is valid event start day', async () => {
@@ -395,6 +397,9 @@ test('today is valid event start day', async () => {
   fireEvent.blur(dateInput);
   await waitFor(() => {
     expect(dateInput).toBeValid();
+    expect(dateInput).not.toHaveAttribute('aria-describedby');
+    expect(
+      screen.queryByText(messages.form.validation.date.mustNotInThePast)
+    ).not.toBeInTheDocument();
   });
-  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 });

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -369,11 +369,11 @@ test('yesterday is not valid event start day', async () => {
   fireEvent.blur(dateInput);
   await waitFor(() => {
     expect(dateInput).toBeInvalid();
-    expect(dateInput).toHaveAttribute('aria-describedby');
-    expect(
-      screen.queryByText(messages.form.validation.date.mustNotInThePast)
-    ).toBeInTheDocument();
   });
+  expect(dateInput).toHaveAttribute('aria-describedby');
+  expect(
+    screen.queryByText(messages.form.validation.date.mustNotInThePast)
+  ).toBeInTheDocument();
 });
 
 test('today is valid event start day', async () => {
@@ -397,9 +397,9 @@ test('today is valid event start day', async () => {
   fireEvent.blur(dateInput);
   await waitFor(() => {
     expect(dateInput).toBeValid();
-    expect(dateInput).not.toHaveAttribute('aria-describedby');
-    expect(
-      screen.queryByText(messages.form.validation.date.mustNotInThePast)
-    ).not.toBeInTheDocument();
   });
+  expect(dateInput).not.toHaveAttribute('aria-describedby');
+  expect(
+    screen.queryByText(messages.form.validation.date.mustNotInThePast)
+  ).not.toBeInTheDocument();
 });

--- a/src/domain/occurrence/eventOccurrenceForm/ValidationSchema.ts
+++ b/src/domain/occurrence/eventOccurrenceForm/ValidationSchema.ts
@@ -1,8 +1,7 @@
-import isBefore from 'date-fns/isBefore';
-import isFuture from 'date-fns/isFuture';
-import parseDate from 'date-fns/parse';
+import { isBefore, isToday, parse as parseDate } from 'date-fns';
 import * as Yup from 'yup';
 
+import { isTodayOrLater } from '../../../utils/dateUtils';
 import { VALIDATION_MESSAGE_KEYS } from '../../app/i18n/constants';
 
 const addMinValidationMessage = (
@@ -30,8 +29,10 @@ export default Yup.object().shape({
   date: Yup.date()
     .typeError(VALIDATION_MESSAGE_KEYS.DATE)
     .required(VALIDATION_MESSAGE_KEYS.DATE_REQUIRED)
-    .test('isInTheFuture', VALIDATION_MESSAGE_KEYS.DATE_FUTURE, (value: Date) =>
-      isFuture(value)
+    .test(
+      'isTodayOrInTheFuture',
+      VALIDATION_MESSAGE_KEYS.DATE_TODAY_OR_LATER,
+      isTodayOrLater
     ),
   startsAt: Yup.string()
     .required(VALIDATION_MESSAGE_KEYS.TIME_REQUIRED)

--- a/src/domain/occurrence/eventOccurrenceForm/ValidationSchema.ts
+++ b/src/domain/occurrence/eventOccurrenceForm/ValidationSchema.ts
@@ -1,4 +1,5 @@
-import { isBefore, isToday, parse as parseDate } from 'date-fns';
+import isBefore from 'date-fns/isBefore';
+import parseDate from 'date-fns/parse';
 import * as Yup from 'yup';
 
 import { isTodayOrLater } from '../../../utils/dateUtils';

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,5 @@
+import { isFuture, isToday } from 'date-fns';
+
+export const isTodayOrLater = (date: Date) => {
+  return isToday(date) || isFuture(date);
+};


### PR DESCRIPTION
## Description
Allow current day to be valid event starting day. Also changed error message text.
## Issues
### Closes
**[PT-632](https://helsinkisolutionoffice.atlassian.net/browse/PT-632):** 
### Related
## Testin
### Automated tests
Few component tests added for testing yesterday date and current date
### Manual testing
## Screenshots
Note! gif recorded on first of december, so it is the current day in it.
![date](https://user-images.githubusercontent.com/7648194/100721920-a767b700-33c8-11eb-8472-a72b9541a601.gif)
