### PR TITLE
Pt-633: Enrolment can't start after event start and not in the past

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,4 @@
 !package.json
 !tsconfig.json
 !yarn.lock
-*/*/testUtils.ts
+*/*/testUtils.tsx

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
       "query.ts",
       "mutation.ts",
       "types.ts",
-      "testUtils.ts",
+      "testUtils.tsx",
       "/icons/",
       "serviceWorker.ts",
       "./src/index.tsx",

--- a/src/domain/app/i18n/constants.ts
+++ b/src/domain/app/i18n/constants.ts
@@ -9,7 +9,7 @@ export enum VALIDATION_MESSAGE_KEYS {
   URL = 'form.validation.string.url',
   DATE_REQUIRED = 'form.validation.date.required',
   DATE = 'form.validation.string.date',
-  DATE_TODAY_OR_LATER = 'form.validation.date.mustNotInThePast',
+  DATE_IN_THE_FUTURE = 'form.validation.date.mustNotInThePast',
   DATE_MIN = 'form.validation.date.min',
   DATE_MAX = 'form.validation.date.max',
   TIME = 'form.validation.string.time',

--- a/src/domain/event/eventForm/ValidationSchema.ts
+++ b/src/domain/event/eventForm/ValidationSchema.ts
@@ -39,7 +39,7 @@ const createValidationSchemaYup = (
       .required(VALIDATION_MESSAGE_KEYS.DATE_REQUIRED)
       .test(
         'isInTheFuture',
-        VALIDATION_MESSAGE_KEYS.DATE_TODAY_OR_LATER,
+        VALIDATION_MESSAGE_KEYS.DATE_IN_THE_FUTURE,
         isFuture
       )
       .when(
@@ -107,7 +107,7 @@ export const createEventSchema = {
     .required(VALIDATION_MESSAGE_KEYS.DATE_REQUIRED)
     .test(
       'isTodayOrInTheFuture',
-      VALIDATION_MESSAGE_KEYS.DATE_TODAY_OR_LATER,
+      VALIDATION_MESSAGE_KEYS.DATE_IN_THE_FUTURE,
       isTodayOrLater
     ),
   occurrenceStartsAt: Yup.string()

--- a/src/domain/event/eventForm/ValidationSchema.ts
+++ b/src/domain/event/eventForm/ValidationSchema.ts
@@ -45,24 +45,22 @@ const createValidationSchemaYup = (
       .when(
         ['occurrenceDate', 'occurrenceStartsAt'],
         (
-          occurenceDate: Date,
+          occurrenceDate: Date,
           occurrenceStartsAt: string,
           schema: Yup.DateSchema
         ) => {
-          if (isValidDate(occurenceDate)) {
+          if (isValidDate(occurrenceDate)) {
             const isValid = isValidTime(occurrenceStartsAt);
-            const occurenceStart = isValid
-              ? parseDate(occurrenceStartsAt, 'HH:mm', occurenceDate)
-              : occurenceDate;
+            const occurrenceStart = isValid
+              ? parseDate(occurrenceStartsAt, 'HH:mm', occurrenceDate)
+              : occurrenceDate;
             return schema.test(
               'isBefore',
               () => ({
                 key: VALIDATION_MESSAGE_KEYS.DATE_MAX,
-                max: formatDate(occurenceStart, DATETIME_FORMAT),
+                max: formatDate(occurrenceStart, DATETIME_FORMAT),
               }),
-              (enrolmentStart: Date) => {
-                return enrolmentStart < occurenceStart;
-              }
+              (enrolmentStart: Date) => enrolmentStart < occurrenceStart
             );
           }
           return schema;

--- a/src/domain/event/eventForm/ValidationSchema.ts
+++ b/src/domain/event/eventForm/ValidationSchema.ts
@@ -1,4 +1,5 @@
 import isBefore from 'date-fns/isBefore';
+import isFuture from 'date-fns/isFuture';
 import isValidDate from 'date-fns/isValid';
 import parseDate from 'date-fns/parse';
 import * as Yup from 'yup';
@@ -37,9 +38,9 @@ const createValidationSchemaYup = (
       .typeError(VALIDATION_MESSAGE_KEYS.DATE)
       .required(VALIDATION_MESSAGE_KEYS.DATE_REQUIRED)
       .test(
-        'isTodayOrInTheFuture',
+        'isInTheFuture',
         VALIDATION_MESSAGE_KEYS.DATE_TODAY_OR_LATER,
-        isTodayOrLater
+        isFuture
       )
       .when(
         ['occurrenceDate', 'occurrenceStartsAt'],

--- a/src/domain/event/eventForm/__tests__/EventForm.test.tsx
+++ b/src/domain/event/eventForm/__tests__/EventForm.test.tsx
@@ -90,7 +90,7 @@ describe('eventForm Tests', () => {
     ).not.toBeInTheDocument();
   });
 
-  it.only('enrolment must start after event date', async () => {
+  it('enrolment must start after event date', async () => {
     const currentDate = new Date(2020, 7, 2);
     advanceTo(currentDate);
     renderForm();

--- a/src/domain/event/eventForm/__tests__/EventForm.test.tsx
+++ b/src/domain/event/eventForm/__tests__/EventForm.test.tsx
@@ -1,12 +1,27 @@
+import { format } from 'date-fns';
 import { axe } from 'jest-axe';
+import { advanceTo, clear } from 'jest-date-mock';
 import * as React from 'react';
 import wait from 'waait';
 
-import { act, render } from '../../../../utils/testUtils';
+import { DATE_FORMAT } from '../../../../common/components/datepicker/contants';
+import {
+  act,
+  fireEvent,
+  render,
+  renderWithRoute,
+  screen,
+  userEvent,
+  waitFor,
+} from '../../../../utils/testUtils';
 import EventForm, { defaultInitialValues } from '../EventForm';
 
-test('test for accessibility violations', async () => {
-  const { container } = render(
+afterAll(() => {
+  clear();
+});
+
+const renderForm = () =>
+  render(
     <EventForm
       title="Testilomake"
       persons={[]}
@@ -18,8 +33,68 @@ test('test for accessibility violations', async () => {
     />
   );
 
+test('test for accessibility violations', async () => {
+  const { container } = renderForm();
+
   await act(wait);
 
   const result = await axe(container);
   expect(result).toHaveNoViolations();
+});
+
+test('enrolment must start after event date', async () => {
+  const currentDate = new Date(2020, 7, 2);
+  advanceTo(currentDate);
+  renderForm();
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+  });
+
+  const eventStartDateInput = screen.getByRole('textbox', {
+    name: 'Päivämäärä',
+  });
+  const eventTimeStartInput = screen.getByRole('textbox', {
+    name: 'Alkaa klo',
+  });
+  const enrolmentStartInput = screen.getByRole('textbox', {
+    name: /Ilmoittautuminen alkaa/g,
+  });
+  const currentDateFormatted = format(currentDate, DATE_FORMAT);
+  userEvent.click(eventStartDateInput);
+  userEvent.type(eventStartDateInput, currentDateFormatted);
+  fireEvent.blur(eventStartDateInput);
+
+  await waitFor(() => {
+    expect(eventStartDateInput).toBeValid();
+  });
+
+  userEvent.click(eventTimeStartInput);
+  userEvent.type(eventTimeStartInput, '15:00');
+  fireEvent.blur(eventTimeStartInput);
+
+  await waitFor(() => {
+    expect(eventTimeStartInput).toBeValid();
+  });
+
+  userEvent.click(enrolmentStartInput);
+  userEvent.type(enrolmentStartInput, `${currentDateFormatted} 15:30`);
+  fireEvent.blur(enrolmentStartInput);
+  await waitFor(() => {
+    expect(enrolmentStartInput).toBeInvalid();
+  });
+  expect(enrolmentStartInput).toHaveAttribute('aria-describedby');
+  expect(
+    screen.queryByText(
+      `Päivämäärän on oltava ennen ${currentDateFormatted} 15:00`
+    )
+  ).toBeInTheDocument();
+  userEvent.click(enrolmentStartInput);
+  userEvent.clear(enrolmentStartInput);
+  userEvent.type(enrolmentStartInput, `${currentDateFormatted} 14:30`);
+  fireEvent.blur(enrolmentStartInput);
+  await waitFor(() => {
+    expect(enrolmentStartInput).toBeValid();
+  });
+  expect(enrolmentStartInput).not.toHaveAttribute('aria-describedby');
 });

--- a/src/domain/occurrence/CreateOccurrencePage.tsx
+++ b/src/domain/occurrence/CreateOccurrencePage.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../generated/graphql';
 import useLocale from '../../hooks/useLocale';
 import { useSearchParams } from '../../hooks/useQuery';
+import { isValidTime } from '../../utils/dateUtils';
 import getLocalizedString from '../../utils/getLocalizedString';
 import scrollToTop from '../../utils/scrollToTop';
 import Container from '../app/layout/Container';
@@ -33,7 +34,6 @@ import { createOrUpdateVenue } from '../venue/utils';
 import EventOccurrenceForm, {
   defaultInitialValues,
 } from './eventOccurrenceForm/EventOccurrenceForm';
-import { isValidTime } from './eventOccurrenceForm/ValidationSchema';
 import styles from './occurrencePage.module.scss';
 import { OccurrenceFormFields } from './types';
 import { getOccurrencePayload } from './utils';

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -4,7 +4,6 @@ import { advanceTo, clear } from 'jest-date-mock';
 import range from 'lodash/range';
 import * as React from 'react';
 
-import { DATE_FORMAT } from '../../../common/components/datepicker/contants';
 import * as graphql from '../../../generated/graphql';
 import { runCommonEventFormTests } from '../../../utils/CommonEventFormTests';
 import {

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -24,7 +24,6 @@ import {
   waitFor,
 } from '../../../utils/testUtils';
 import apolloClient from '../../app/apollo/apolloClient';
-import messages from '../../app/i18n/fi.json';
 import { ROUTES } from '../../app/routes/constants';
 import CreateOccurrencePage from '../CreateOccurrencePage';
 
@@ -353,9 +352,7 @@ test('yesterday is not valid event start day', async () => {
     expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
   });
 
-  const dateInput = screen.getByLabelText(
-    messages.eventOccurrenceForm.labelDate
-  );
+  const dateInput = screen.getByRole('textbox', { name: 'Päivämäärä' });
   userEvent.click(dateInput);
   userEvent.type(dateInput, format(addDays(currentDate, -1), DATE_FORMAT));
   fireEvent.blur(dateInput);
@@ -364,7 +361,7 @@ test('yesterday is not valid event start day', async () => {
   });
   expect(dateInput).toHaveAttribute('aria-describedby');
   expect(
-    screen.queryByText(messages.form.validation.date.mustNotInThePast)
+    screen.queryByText('Päivämäärä ei voi olla menneisyydessä')
   ).toBeInTheDocument();
 });
 
@@ -381,9 +378,7 @@ test('today is valid event start day', async () => {
     expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
   });
 
-  const dateInput = screen.getByLabelText(
-    messages.eventOccurrenceForm.labelDate
-  );
+  const dateInput = screen.getByRole('textbox', { name: 'Päivämäärä' });
   userEvent.click(dateInput);
   userEvent.type(dateInput, format(currentDate, DATE_FORMAT));
   fireEvent.blur(dateInput);
@@ -392,6 +387,6 @@ test('today is valid event start day', async () => {
   });
   expect(dateInput).not.toHaveAttribute('aria-describedby');
   expect(
-    screen.queryByText(messages.form.validation.date.mustNotInThePast)
+    screen.queryByText('Päivämäärä ei voi olla menneisyydessä')
   ).not.toBeInTheDocument();
 });

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -345,8 +345,7 @@ test('does not initializes values from URL if they are invalid', async () => {
 });
 
 describe('common event form tests', () => {
-  const currentDate = new Date(2020, 7, 2);
-  runCommonEventFormTests(() =>
+  runCommonEventFormTests((currentDate: Date) =>
     InitializeMocksAndRenderPage(
       {
         routes: [ROUTES.CREATE_OCCURRENCE.replace(':id', eventMock.id)],

--- a/src/domain/occurrence/eventOccurrenceForm/ValidationSchema.ts
+++ b/src/domain/occurrence/eventOccurrenceForm/ValidationSchema.ts
@@ -2,7 +2,7 @@ import isBefore from 'date-fns/isBefore';
 import parseDate from 'date-fns/parse';
 import * as Yup from 'yup';
 
-import { isTodayOrLater } from '../../../utils/dateUtils';
+import { isTodayOrLater, isValidTime } from '../../../utils/dateUtils';
 import { VALIDATION_MESSAGE_KEYS } from '../../app/i18n/constants';
 
 const addMinValidationMessage = (
@@ -22,9 +22,6 @@ const addMaxValidationMessage = (
   max: param.max,
   key: VALIDATION_MESSAGE_KEYS.NUMBER_MAX,
 });
-
-export const isValidTime = (time: string) =>
-  /^(([01][0-9])|(2[0-3]))(:|\.)[0-5][0-9]$/.test(time);
 
 export default Yup.object().shape({
   date: Yup.date()

--- a/src/domain/occurrence/eventOccurrenceForm/ValidationSchema.ts
+++ b/src/domain/occurrence/eventOccurrenceForm/ValidationSchema.ts
@@ -29,7 +29,7 @@ export default Yup.object().shape({
     .required(VALIDATION_MESSAGE_KEYS.DATE_REQUIRED)
     .test(
       'isTodayOrInTheFuture',
-      VALIDATION_MESSAGE_KEYS.DATE_TODAY_OR_LATER,
+      VALIDATION_MESSAGE_KEYS.DATE_IN_THE_FUTURE,
       isTodayOrLater
     ),
   startsAt: Yup.string()

--- a/src/utils/CommonEventFormTests.ts
+++ b/src/utils/CommonEventFormTests.ts
@@ -1,8 +1,13 @@
 import { addDays, format } from 'date-fns';
+import parseDate from 'date-fns/parse';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { DATE_FORMAT } from '../common/components/datepicker/contants';
 import {
+  DATE_FORMAT,
+  DATETIME_FORMAT,
+} from '../common/components/datepicker/contants';
+import {
+  act,
   CustomRenderResult,
   fireEvent,
   screen,
@@ -11,7 +16,7 @@ import {
 } from './testUtils';
 
 export const runCommonEventFormTests = (
-  renderForm: () => CustomRenderResult
+  renderForm: (currentDate: Date) => CustomRenderResult
 ) => {
   describe('Common event form tests', () => {
     afterAll(() => {
@@ -23,9 +28,9 @@ export const runCommonEventFormTests = (
     };
 
     it('yesterday is not valid event start day', async () => {
-      const currentDate = new Date(2020, 7, 2);
+      const currentDate = new Date('2008-08-01');
       setCurrentSystemDate(currentDate);
-      renderForm();
+      renderForm(currentDate);
 
       await waitFor(() => {
         expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
@@ -47,7 +52,7 @@ export const runCommonEventFormTests = (
     it('today is valid event start day', async () => {
       const currentDate = new Date(2020, 7, 2);
       setCurrentSystemDate(currentDate);
-      renderForm();
+      renderForm(currentDate);
 
       await waitFor(() => {
         expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();

--- a/src/utils/CommonEventFormTests.ts
+++ b/src/utils/CommonEventFormTests.ts
@@ -1,13 +1,8 @@
 import { addDays, format } from 'date-fns';
-import parseDate from 'date-fns/parse';
 import { advanceTo, clear } from 'jest-date-mock';
 
+import { DATE_FORMAT } from '../common/components/datepicker/contants';
 import {
-  DATE_FORMAT,
-  DATETIME_FORMAT,
-} from '../common/components/datepicker/contants';
-import {
-  act,
   CustomRenderResult,
   fireEvent,
   screen,
@@ -23,13 +18,9 @@ export const runCommonEventFormTests = (
       clear();
     });
 
-    const setCurrentSystemDate = (currentDate: Date) => {
-      advanceTo(currentDate);
-    };
-
     it('yesterday is not valid event start day', async () => {
       const currentDate = new Date('2008-08-01');
-      setCurrentSystemDate(currentDate);
+      advanceTo(currentDate);
       renderForm(currentDate);
 
       await waitFor(() => {
@@ -51,7 +42,7 @@ export const runCommonEventFormTests = (
 
     it('today is valid event start day', async () => {
       const currentDate = new Date(2020, 7, 2);
-      setCurrentSystemDate(currentDate);
+      advanceTo(currentDate);
       renderForm(currentDate);
 
       await waitFor(() => {

--- a/src/utils/CommonEventFormTests.ts
+++ b/src/utils/CommonEventFormTests.ts
@@ -1,0 +1,69 @@
+import { addDays, format } from 'date-fns';
+import { advanceTo, clear } from 'jest-date-mock';
+
+import { DATE_FORMAT } from '../common/components/datepicker/contants';
+import {
+  CustomRenderResult,
+  fireEvent,
+  screen,
+  userEvent,
+  waitFor,
+} from './testUtils';
+
+export const runCommonEventFormTests = (
+  renderForm: () => CustomRenderResult
+) => {
+  describe('Common event form tests', () => {
+    afterAll(() => {
+      clear();
+    });
+
+    const setCurrentSystemDate = (currentDate: Date) => {
+      advanceTo(currentDate);
+    };
+
+    it('yesterday is not valid event start day', async () => {
+      const currentDate = new Date(2020, 7, 2);
+      setCurrentSystemDate(currentDate);
+      renderForm();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+      });
+
+      const dateInput = screen.getByRole('textbox', { name: 'Päivämäärä' });
+      userEvent.click(dateInput);
+      userEvent.type(dateInput, format(addDays(currentDate, -1), DATE_FORMAT));
+      fireEvent.blur(dateInput);
+      await waitFor(() => {
+        expect(dateInput).toBeInvalid();
+      });
+      expect(dateInput).toHaveAttribute('aria-describedby');
+      expect(
+        screen.queryByText('Päivämäärä ei voi olla menneisyydessä')
+      ).toBeInTheDocument();
+    });
+
+    it('today is valid event start day', async () => {
+      const currentDate = new Date(2020, 7, 2);
+      setCurrentSystemDate(currentDate);
+      renderForm();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+      });
+
+      const dateInput = screen.getByRole('textbox', { name: 'Päivämäärä' });
+      userEvent.click(dateInput);
+      userEvent.type(dateInput, format(currentDate, DATE_FORMAT));
+      fireEvent.blur(dateInput);
+      await waitFor(() => {
+        expect(dateInput).toBeValid();
+      });
+      expect(dateInput).not.toHaveAttribute('aria-describedby');
+      expect(
+        screen.queryByText('Päivämäärä ei voi olla menneisyydessä')
+      ).not.toBeInTheDocument();
+    });
+  });
+};

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -3,3 +3,6 @@ import { isFuture, isToday } from 'date-fns';
 export const isTodayOrLater = (date: Date) => {
   return isToday(date) || isFuture(date);
 };
+
+export const isValidTime = (time: string) =>
+  /^(([01][0-9])|(2[0-3]))(:|\.)[0-5][0-9]$/.test(time);

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -81,7 +81,7 @@ type CustomRender = {
   ): CustomRenderResult;
 };
 
-type CustomRenderResult = RenderResult & { history: History };
+export type CustomRenderResult = RenderResult & { history: History };
 
 export { customRender as render, renderWithRoute, reduxStore };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "src/**/*.stories.*",
     "**/*.test.*",
     "src/utils/testUtils.tsx",
-    "src/utils/mockDataUtils.ts"
+    "src/utils/mockDataUtils.ts",
+    "src/utils/CommonEventFormTests.ts"
   ]
 }


### PR DESCRIPTION
## Description :sparkles:
Currently there is no validation for enrolment date. These are added:
- enrolment cannot start in the past
- enrolment cannot start after the event has started
Both validation checks the inputted hours too.


## Issues :bug:
### Closes :no_good_woman:
https://helsinkisolutionoffice.atlassian.net/browse/PT-633

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:
Previously (no errors):
![Screenshot 2021-01-27 at 12 32 02 PM](https://user-images.githubusercontent.com/7648194/105979020-e0a46680-609b-11eb-9929-b8469f5cf4e4.png)
After:
- Enrolment cannot start in the past
<img width="471" alt="Screenshot 2021-01-27 at 12 19 46 PM" src="https://user-images.githubusercontent.com/7648194/105979178-07fb3380-609c-11eb-9765-8a1204c552e5.png">
- enrolment cannot start after the event has started
<img width="478" alt="Screenshot 2021-01-27 at 12 20 17 PM" src="https://user-images.githubusercontent.com/7648194/105979206-0f224180-609c-11eb-98a9-75899edc951a.png">

## Additional notes :spiral_notepad:

