### PR TITLE
Fixed the PlaceSelector query to include places without events.

### DIFF
--- a/src/domain/event/__tests__/CreateEventPage.test.tsx
+++ b/src/domain/event/__tests__/CreateEventPage.test.tsx
@@ -349,6 +349,7 @@ const mocks = [
       skip: false,
       variables: {
         dataSource: 'tprek',
+        showAllPlaces: true,
         pageSize: AUTOSUGGEST_OPTIONS_AMOUNT,
         text: 'Sellon',
       },

--- a/src/domain/place/PlaceSelector.tsx
+++ b/src/domain/place/PlaceSelector.tsx
@@ -59,6 +59,7 @@ const PlaceSelector: React.FC<Props> = ({
     variables: {
       dataSource: 'tprek',
       pageSize: AUTOSUGGEST_OPTIONS_AMOUNT,
+      showAllPlaces: true,
       text: searchValue,
     },
   });


### PR DESCRIPTION

## Description :sparkles:

PT-672 PlaceSelector was not showing places with 0 events, but by adding showAllPlaces to usePlacesQuery hook's variables, they are now included.

## Issues :bug:
### Closes :no_good_woman:
**[PT-672](https://helsinkisolutionoffice.atlassian.net/browse/PT-672):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

CreateEventPage.test.tsx updated.

### Manual testing :construction_worker_man:

Test queries
Graphql place query from Kultus - Result is 2 entries:

https://palvelutarjotin-api.test.kuva.hel.ninja/graphql#operationName=Places&query=query Places(%24dataSource%3A String%2C %24divisions%3A [String]%2C %24page%3A Int%2C %24pageSize%3A Int%2C %24showAllPlaces%3A Boolean%2C %24sort%3A String%2C %24text%3A String) { places(dataSource%3A %24dataSource%2C divisions%3A %24divisions%2C page%3A %24page%2C pageSize%3A %24pageSize%2C showAllPlaces%3A %24showAllPlaces%2C sort%3A %24sort%2C text%3A %24text) { meta { count next previous __typename } data { ...placeFields __typename } __typename } } fragment placeFields on Place { id internalId name { ...localisedFields __typename } streetAddress { ...localisedFields __typename } addressLocality { ...localisedFields __typename } telephone { ...localisedFields __typename } __typename } fragment localisedFields on LocalisedObject { en fi sv __typename } &variables={ "dataSource"%3A "tprek"%2C "pageSize"%3A 20%2C "text"%3A "Meriharju"%2C "showAllPlaces"%3A true }

Production linkedevents - Result is 2 entries:

https://api.hel.fi/linkedevents/v1/place/?text=Meriharjun&show_all_places=true&data_source=tprek

Test linkedevents - Result is 2 entries: 

https://api.hel.fi/linkedevents-test/v1/place/?text=Meriharjun&show_all_places=true&data_source=tprek

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: