### PR TITLE
disallow .only tests on pre-commit hook + run eslint first to fail faster

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
     "plugin:import/typescript",
     "plugin:testcafe/recommended"
   ],
-  "plugins": ["simple-import-sort", "testcafe"],
+  "plugins": ["simple-import-sort", "testcafe", "no-only-tests"],
 
   "rules": {
     "@typescript-eslint/brace-style": [
@@ -30,7 +30,8 @@
     "sort-imports": "off",
     "import/order": "off",
     "simple-import-sort/sort": "error",
-    "import/named": "off"
+    "import/named": "off",
+    "no-only-tests/no-only-tests": "error"
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-simple-import-sort": "^5.0.2",
     "eslint-plugin-testcafe": "^0.2.1",
@@ -172,9 +173,9 @@
   },
   "lint-staged": {
     "src/**/*.{tsx,ts}": [
+      "eslint --fix",
       "yarn test:staged",
-      "prettier --write",
-      "eslint --fix"
+      "prettier --write"
     ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8214,6 +8214,11 @@ eslint-plugin-jsx-a11y@6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
+eslint-plugin-no-only-tests@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz#7d565434aa7d16ccc7eea957c391d98f827332ca"
+  integrity sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==
+
 eslint-plugin-prettier@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz#ae116a0fc0e598fdae48743a4430903de5b4e6ca"


### PR DESCRIPTION
disallow .only tests on pre-commit hook + run eslint first to fail faster

## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:
**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: