### PR TITLE
Removed language field from event form

### DIFF
--- a/src/domain/event/__tests__/CreateEventPage.test.tsx
+++ b/src/domain/event/__tests__/CreateEventPage.test.tsx
@@ -118,10 +118,7 @@ const createEventVariables = {
         internalId: getKeywordId(targetGroupId2),
       },
     ],
-    inLanguage: [
-      { internalId: '/language/en/' },
-      { internalId: '/language/fi/' },
-    ],
+    inLanguage: [],
     keywords: [
       {
         internalId: getKeywordId(keywordId),
@@ -629,12 +626,6 @@ test('event can be created with form', async () => {
       'testi123@testi123.fi'
     );
     expect(screen.getByLabelText('Puhelinnumero')).toHaveValue('123321123');
-  });
-
-  await testMultiDropdownValues({
-    dropdownLabel: /tapahtuman kielet/i,
-    dropdownTestId: 'in-language-dropdown',
-    values: ['Englanti', 'Suomi'],
   });
 
   await testMultiDropdownValues({

--- a/src/domain/event/__tests__/EditEventPage.test.tsx
+++ b/src/domain/event/__tests__/EditEventPage.test.tsx
@@ -322,10 +322,6 @@ test('edit event form initializes and submits correctly', async () => {
     contactInfo.getByLabelText(/Nimi/, { selector: 'button' })
   ).toHaveTextContent(personName);
 
-  const dropdown = within(screen.getByTestId('in-language-dropdown'));
-  expect(dropdown.queryByText('Suomi')).toBeInTheDocument();
-  expect(dropdown.queryByText('Englanti')).toBeInTheDocument();
-
   await waitFor(() => {
     expect(screen.getAllByText('Sellon kirjasto')).toHaveLength(2);
   });

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -16,7 +16,6 @@ import TimepickerField from '../../../common/components/form/fields/TimepickerFi
 import FocusToFirstError from '../../../common/components/form/FocusToFirstError';
 import FormGroup from '../../../common/components/form/FormGroup';
 import ConfirmationModal from '../../../common/components/modal/ConfirmationModal';
-import { EVENT_LANGUAGES } from '../../../constants';
 import { EventQuery, PersonFieldsFragment } from '../../../generated/graphql';
 import { Language } from '../../../types';
 import { VALIDATION_MESSAGE_KEYS } from '../../app/i18n/constants';
@@ -324,30 +323,7 @@ const EventForm = <T extends FormFields>({
                     data-testid="in-language-dropdown"
                   >
                     <h2>{t('eventForm.categorisation.title')}</h2>
-                    <div className={styles.languageRow}>
-                      <div>
-                        <FormGroup>
-                          <Field
-                            component={MultiDropdownField}
-                            label={t(
-                              'eventForm.categorisation.labelInLanguage'
-                            )}
-                            name="inLanguage"
-                            options={Object.values(EVENT_LANGUAGES).map(
-                              (language) => ({
-                                label: t(`common.languages.${language}`),
-                                value: language,
-                              })
-                            )}
-                            clearButtonAriaLabel={t(
-                              'eventForm.accessibility.inLanguageDropdown.clearButtonAriaLabel'
-                            )}
-                            selectedItemRemoveButtonAriaLabel={t(
-                              'eventForm.accessibility.inLanguageDropdown.selectedItemRemoveButtonAriaLabel'
-                            )}
-                          />
-                        </FormGroup>
-                      </div>
+                    <div>
                       <div data-testid="audience-dropdown">
                         <FormGroup>
                           <Field
@@ -366,7 +342,7 @@ const EventForm = <T extends FormFields>({
                         </FormGroup>
                       </div>
                     </div>
-                    <div className={styles.languageRow}>
+                    <div>
                       <div data-testid="categories-dropdown">
                         <FormGroup>
                           <Field
@@ -388,6 +364,8 @@ const EventForm = <T extends FormFields>({
                           />
                         </FormGroup>
                       </div>
+                    </div>
+                    <div>
                       <div data-testid="additional-criteria-dropdown">
                         <FormGroup>
                           <Field
@@ -410,8 +388,7 @@ const EventForm = <T extends FormFields>({
                         </FormGroup>
                       </div>
                     </div>
-
-                    <div className={styles.keywordRow}>
+                    <div>
                       <div data-testid="keywords-dropdown">
                         <FormGroup>
                           <Field
@@ -430,7 +407,10 @@ const EventForm = <T extends FormFields>({
                           />
                         </FormGroup>
                       </div>
-                      <div data-testid="neededOccurrences-stepper">
+                      <div
+                        className={styles.neededOccurrencesRow}
+                        data-testid="neededOccurrences-stepper"
+                      >
                         <FormGroup>
                           <Field
                             labelText={t(

--- a/src/domain/event/eventForm/eventForm.module.scss
+++ b/src/domain/event/eventForm/eventForm.module.scss
@@ -31,21 +31,22 @@
     }
   }
 
-  .languageRow {
-    display: grid;
-    grid-gap: var(--grid-gap);
-
-    @include respond_above(sm) {
-      grid-template-columns: 1fr 1fr;
-    }
-  }
-
   .keywordRow {
     display: grid;
     grid-gap: var(--grid-gap);
-  
+
     @include respond_above(sm) {
       grid-template-columns: 3fr 1fr;
+    }
+  }
+
+  .neededOccurrencesRow {
+    display: grid;
+    grid-gap: var(--grid-gap);
+    margin-bottom: var(--spacing-m);
+
+    @include respond_above(sm) {
+      grid-template-columns: 1fr 3fr;
     }
   }
 

--- a/src/domain/occurrence/EditOccurrencePage.tsx
+++ b/src/domain/occurrence/EditOccurrencePage.tsx
@@ -188,8 +188,8 @@ const EditOccurrencePage: React.FC = () => {
         ? formatDate(new Date(occurrenceData?.occurrence?.endTime), 'HH:mm')
         : '',
       languages:
-        occurrenceData?.occurrence?.languages.map((language) =>
-          language.id.toUpperCase()
+        occurrenceData?.occurrence?.languages.edges.map(
+          (edge) => edge?.node?.id || ''
         ) || [],
       oneGroupFills:
         occurrenceData?.occurrence?.seatType ===

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -285,7 +285,7 @@ test('can create new occurrence with form', async () => {
         input: {
           amountOfSeats: 1,
           endTime: new Date('2020-08-13T10:00:00.000Z'),
-          languages: [{ id: 'EN' }, { id: 'FI' }],
+          languages: [{ id: 'en' }, { id: 'fi' }],
           maxGroupSize: 20,
           minGroupSize: 10,
           pEventId: 'UGFsdmVsdXRhcmpvdGluRXZlbnROb2RlOjcw',

--- a/src/domain/occurrence/__tests__/EditOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/EditOccurrencePage.test.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import * as graphql from '../../../generated/graphql';
 import {
   fakeEvent,
+  fakeLanguages,
   fakeLocalizedObject,
   fakeOccurrence,
   fakeOccurrences,
@@ -45,10 +46,10 @@ const occurrence = {
 
   startTime: '2020-08-03T09:00:00+00:00',
   endTime: '2020-08-03T09:30:00+00:00',
-  languages: [
-    { id: 'en', name: 'English', __typename: 'LanguageType' },
-    { id: 'fi', name: 'Finnish', __typename: 'LanguageType' },
-  ] as graphql.LanguageType[],
+  languages: fakeLanguages([
+    { id: 'en', name: 'English' },
+    { id: 'fi', name: 'Finnish' },
+  ]),
 };
 
 const fakeOccurrenceOverrides: Partial<graphql.OccurrenceNode>[] = [
@@ -232,7 +233,7 @@ test('initializes edit occurrence form correctly', async () => {
           startTime: new Date('2020-08-03T09:00:00.000Z'),
           endTime: new Date('2020-08-03T09:30:00.000Z'),
           id: occurrenceId,
-          languages: [{ id: 'EN' }, { id: 'FI' }],
+          languages: [{ id: 'en' }, { id: 'fi' }],
           maxGroupSize: 2030,
           minGroupSize: 10,
           pEventId: 'UGFsdmVsdXRhcmpvdGluRXZlbnROb2RlOjcw',

--- a/src/domain/occurrence/__tests__/OccurrenceDetailsPage.test.tsx
+++ b/src/domain/occurrence/__tests__/OccurrenceDetailsPage.test.tsx
@@ -10,6 +10,7 @@ import {
 import {
   fakeEnrolments,
   fakeEvent,
+  fakeLanguages,
   fakeLocalizedObject,
   fakeOccurrence,
   fakePerson,
@@ -75,20 +76,16 @@ const occurrenceResult = {
       minGroupSize: 10,
       maxGroupSize: 20,
       seatsTaken: 20,
-      languages: [
+      languages: fakeLanguages([
         {
           id: 'fi',
           name: 'Finnish',
-          __typename: 'LanguageType',
-          occurrences: [] as any,
         },
         {
           id: 'en',
           name: 'English',
-          __typename: 'LanguageType',
-          occurrences: [] as any,
         },
-      ],
+      ]),
       startTime: '2020-09-10T09:00:00+00:00',
       endTime: '2020-09-10T09:30:00+00:00',
       enrolments: fakeEnrolments(2, [

--- a/src/domain/occurrence/eventOccurrenceForm/EventOccurrenceForm.tsx
+++ b/src/domain/occurrence/eventOccurrenceForm/EventOccurrenceForm.tsx
@@ -13,7 +13,8 @@ import FocusToFirstError from '../../../common/components/form/FocusToFirstError
 import FormGroup from '../../../common/components/form/FormGroup';
 import FormHelperText from '../../../common/components/FormHelperText/FormHelperText';
 import TextTitle from '../../../common/components/textTitle/TextTitle';
-import { EventQuery, Language } from '../../../generated/graphql';
+import { EVENT_LANGUAGES } from '../../../constants';
+import { EventQuery } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import formatDate from '../../../utils/formatDate';
 import PlaceInfo from '../../place/placeInfo/PlaceInfo';
@@ -187,7 +188,7 @@ const EventOccurrenceForm: React.FC<Props & GoToPublishingProps> = ({
                     label={t('eventOccurrenceForm.labelLanguages')}
                     name="languages"
                     options={[
-                      ...Object.values(Language).map((language) => ({
+                      ...Object.values(EVENT_LANGUAGES).map((language) => ({
                         label: t(`common.languages.${language.toLowerCase()}`),
                         value: language,
                       })),

--- a/src/domain/occurrence/eventOccurrenceForm/EventOccurrenceForm.tsx
+++ b/src/domain/occurrence/eventOccurrenceForm/EventOccurrenceForm.tsx
@@ -17,6 +17,7 @@ import { EVENT_LANGUAGES } from '../../../constants';
 import { EventQuery } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import formatDate from '../../../utils/formatDate';
+import sortFavorably from '../../../utils/sortFavorably';
 import PlaceInfo from '../../place/placeInfo/PlaceInfo';
 import VenueDataFields from '../../venue/venueDataFields/VenueDataFields';
 import { OccurrenceFormFields } from '../types';
@@ -87,6 +88,29 @@ const EventOccurrenceForm: React.FC<Props & GoToPublishingProps> = ({
   const [editPlaceMode, setEditPlaceMode] = React.useState(
     Boolean(initialValues.placeId)
   );
+
+  const languages = React.useMemo(() => {
+    const languagesOrder = sortFavorably(
+      Object.values(EVENT_LANGUAGES).map((language) =>
+        t(`common.languages.${language.toLowerCase()}`)
+      ),
+      [
+        EVENT_LANGUAGES.FI,
+        EVENT_LANGUAGES.SV,
+        EVENT_LANGUAGES.EN,
+      ].map((language) => t(`common.languages.${language.toLowerCase()}`))
+    );
+
+    return Object.values(EVENT_LANGUAGES)
+      .map((language) => ({
+        label: t(`common.languages.${language.toLowerCase()}`),
+        value: language,
+      }))
+      .sort(
+        (a, b) =>
+          languagesOrder.indexOf(a.label) - languagesOrder.indexOf(b.label)
+      );
+  }, [t]);
 
   return (
     <Formik
@@ -187,12 +211,7 @@ const EventOccurrenceForm: React.FC<Props & GoToPublishingProps> = ({
                     component={MultiDropdownField}
                     label={t('eventOccurrenceForm.labelLanguages')}
                     name="languages"
-                    options={[
-                      ...Object.values(EVENT_LANGUAGES).map((language) => ({
-                        label: t(`common.languages.${language.toLowerCase()}`),
-                        value: language,
-                      })),
-                    ]}
+                    options={languages}
                   />
                 </FormGroup>
                 <FormGroup>

--- a/src/domain/occurrence/occurrenceGroupInfo/OccurrenceGroupInfo.tsx
+++ b/src/domain/occurrence/occurrenceGroupInfo/OccurrenceGroupInfo.tsx
@@ -13,7 +13,9 @@ interface Props {
 const OccurrenceGroupInfo: React.FC<Props> = ({ occurrence }) => {
   const { t } = useTranslation();
 
-  const languages = occurrence.languages.map((language) => language.id);
+  const languages = occurrence.languages.edges.map(
+    (edge) => edge?.node?.id || ''
+  );
   const amountOfSeats = occurrence.amountOfSeats;
   const maxGroupSize = occurrence.maxGroupSize;
   const minGroupSize = occurrence.minGroupSize;

--- a/src/domain/occurrence/query.ts
+++ b/src/domain/occurrence/query.ts
@@ -1,6 +1,11 @@
 import gql from 'graphql-tag';
 
 export const QUERY_OCCURRENCE = gql`
+  fragment languageFields on LanguageNode {
+    id
+    name
+  }
+
   fragment occurrenceFields on OccurrenceNode {
     id
     pEvent {
@@ -14,8 +19,11 @@ export const QUERY_OCCURRENCE = gql`
     seatType
     remainingSeats
     languages {
-      id
-      name
+      edges {
+        node {
+          ...languageFields
+        }
+      }
     }
     startTime
     endTime

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -55,6 +55,8 @@ export type Query = {
   venues?: Maybe<VenueNodeConnection>;
   venue?: Maybe<VenueNode>;
   cancellingEnrolment?: Maybe<EnrolmentNode>;
+  languages?: Maybe<LanguageNodeConnection>;
+  language?: Maybe<LanguageNode>;
   enrolments?: Maybe<EnrolmentNodeConnection>;
   /** The ID of the object */
   enrolment?: Maybe<EnrolmentNode>;
@@ -129,6 +131,17 @@ export type QueryVenueArgs = {
 };
 
 export type QueryCancellingEnrolmentArgs = {
+  id: Scalars['ID'];
+};
+
+export type QueryLanguagesArgs = {
+  before?: Maybe<Scalars['String']>;
+  after?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+};
+
+export type QueryLanguageArgs = {
   id: Scalars['ID'];
 };
 
@@ -300,7 +313,7 @@ export type OccurrenceNode = Node & {
   studyGroups: StudyGroupNodeConnection;
   placeId: Scalars['String'];
   amountOfSeats: Scalars['Int'];
-  languages: Array<LanguageType>;
+  languages: LanguageNodeConnection;
   cancelled: Scalars['Boolean'];
   seatType: OccurrenceSeatType;
   enrolments: EnrolmentNodeConnection;
@@ -318,6 +331,13 @@ export type OccurrenceNodeContactPersonsArgs = {
 };
 
 export type OccurrenceNodeStudyGroupsArgs = {
+  before?: Maybe<Scalars['String']>;
+  after?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+};
+
+export type OccurrenceNodeLanguagesArgs = {
   before?: Maybe<Scalars['String']>;
   after?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Int']>;
@@ -654,21 +674,27 @@ export enum EnrolmentStatus {
   Declined = 'DECLINED',
 }
 
-export type LanguageType = {
-  __typename?: 'LanguageType';
-  id: Scalars['String'];
-  name: Scalars['String'];
-  occurrences: OccurrenceNodeConnection;
+export type LanguageNodeConnection = {
+  __typename?: 'LanguageNodeConnection';
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<LanguageNodeEdge>>;
 };
 
-export type LanguageTypeOccurrencesArgs = {
-  before?: Maybe<Scalars['String']>;
-  after?: Maybe<Scalars['String']>;
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
-  upcoming?: Maybe<Scalars['Boolean']>;
-  date?: Maybe<Scalars['Date']>;
-  time?: Maybe<Scalars['Time']>;
+/** A Relay edge containing a `LanguageNode` and its cursor. */
+export type LanguageNodeEdge = {
+  __typename?: 'LanguageNodeEdge';
+  /** The item at the end of the edge */
+  node?: Maybe<LanguageNode>;
+  /** A cursor for use in pagination */
+  cursor: Scalars['String'];
+};
+
+export type LanguageNode = Node & {
+  __typename?: 'LanguageNode';
+  id: Scalars['ID'];
+  name: Scalars['String'];
 };
 
 /** An enumeration. */
@@ -1190,7 +1216,7 @@ export type AddOccurrenceMutationInput = {
   pEventId: Scalars['ID'];
   amountOfSeats: Scalars['Int'];
   seatType?: Maybe<SeatType>;
-  languages: Array<Maybe<OccurrenceLanguageInput>>;
+  languages: Array<Maybe<LanguageInput>>;
   clientMutationId?: Maybe<Scalars['String']>;
 };
 
@@ -1209,8 +1235,8 @@ export enum SeatType {
   EnrolmentCount = 'ENROLMENT_COUNT',
 }
 
-export type OccurrenceLanguageInput = {
-  id: Language;
+export type LanguageInput = {
+  id?: Maybe<Scalars['String']>;
 };
 
 export type UpdateOccurrenceMutationPayload = {
@@ -1231,7 +1257,7 @@ export type UpdateOccurrenceMutationInput = {
   pEventId?: Maybe<Scalars['ID']>;
   amountOfSeats?: Maybe<Scalars['Int']>;
   /** If present, should include all languages of the occurrence */
-  languages: Array<Maybe<OccurrenceLanguageInput>>;
+  languages: Array<Maybe<LanguageInput>>;
   seatType?: Maybe<SeatType>;
   clientMutationId?: Maybe<Scalars['String']>;
 };
@@ -2385,6 +2411,11 @@ export type EditOccurrenceMutation = { __typename?: 'Mutation' } & {
   >;
 };
 
+export type LanguageFieldsFragment = { __typename?: 'LanguageNode' } & Pick<
+  LanguageNode,
+  'id' | 'name'
+>;
+
 export type OccurrenceFieldsFragment = { __typename?: 'OccurrenceNode' } & Pick<
   OccurrenceNode,
   | 'id'
@@ -2406,9 +2437,17 @@ export type OccurrenceFieldsFragment = { __typename?: 'OccurrenceNode' } & Pick<
         'id'
       >
     >;
-    languages: Array<
-      { __typename?: 'LanguageType' } & Pick<LanguageType, 'id' | 'name'>
-    >;
+    languages: { __typename?: 'LanguageNodeConnection' } & {
+      edges: Array<
+        Maybe<
+          { __typename?: 'LanguageNodeEdge' } & {
+            node?: Maybe<
+              { __typename?: 'LanguageNode' } & LanguageFieldsFragment
+            >;
+          }
+        >
+      >;
+    };
   };
 
 export type OccurrenceQueryVariables = {
@@ -2788,6 +2827,12 @@ export const OrganisationNodeFieldsFragmentDoc = gql`
   }
   ${PersonFieldsFragmentDoc}
 `;
+export const LanguageFieldsFragmentDoc = gql`
+  fragment languageFields on LanguageNode {
+    id
+    name
+  }
+`;
 export const OccurrenceFieldsFragmentDoc = gql`
   fragment occurrenceFields on OccurrenceNode {
     id
@@ -2802,14 +2847,18 @@ export const OccurrenceFieldsFragmentDoc = gql`
     seatType
     remainingSeats
     languages {
-      id
-      name
+      edges {
+        node {
+          ...languageFields
+        }
+      }
     }
     startTime
     endTime
     placeId
     cancelled
   }
+  ${LanguageFieldsFragmentDoc}
 `;
 export const PEventFieldsFragmentDoc = gql`
   fragment pEventFields on PalvelutarjotinEventNode {

--- a/src/utils/__tests__/sortFavorably.test.ts
+++ b/src/utils/__tests__/sortFavorably.test.ts
@@ -1,0 +1,30 @@
+import sortFavorably from '../sortFavorably';
+
+describe('sortFavorably function', () => {
+  it('adds favored items in the beginning and rest of the items alphabetically', () => {
+    const favored = ['a', 'b', 'c'];
+    [
+      [
+        ['x', 'c', 'a', 'y'],
+        ['a', 'c', 'x', 'y'],
+      ],
+      [
+        ['y', 'b', 'x', 'a'],
+        ['a', 'b', 'x', 'y'],
+      ],
+      [[], []],
+      [['b'], ['b']],
+      [['y'], ['y']],
+    ].forEach(([sortable, result]) =>
+      expect(sortFavorably(sortable, favored)).toEqual(result)
+    );
+  });
+
+  it('should not mutate given parameters', () => {
+    const favored = ['a', 'b', 'c'];
+    const sortable = ['x', 'c', 'a', 'y'];
+    sortFavorably(sortable, favored);
+    expect(favored).toEqual(['a', 'b', 'c']);
+    expect(sortable).toEqual(['x', 'c', 'a', 'y']);
+  });
+});

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -13,7 +13,9 @@ import {
   Keyword,
   KeywordSet,
   Language,
-  LanguageType,
+  LanguageNode,
+  LanguageNodeConnection,
+  LanguageNodeEdge,
   LocalisedObject,
   NotificationType,
   OccurrenceNode,
@@ -300,6 +302,31 @@ export const fakeOccurrenceNodeEdge = (
   __typename: 'OccurrenceNodeEdge',
 });
 
+export const fakeLanguages = (
+  languages?: Partial<LanguageNode>[]
+): LanguageNodeConnection => ({
+  edges: languages.map((language) => fakeLanguageNodeEdge(language)),
+  pageInfo: PageInfoMock,
+  __typename: 'LanguageNodeConnection',
+});
+
+export const fakeLanguageNodeEdge = (
+  overrides?: Partial<LanguageNode>
+): LanguageNodeEdge => ({
+  cursor: '',
+  node: fakeLanguage(overrides),
+  __typename: 'LanguageNodeEdge',
+});
+
+export const fakeLanguage = (
+  overrides?: Partial<LanguageNode>
+): LanguageNode => ({
+  id: 'fi',
+  name: 'Finnish',
+  __typename: 'LanguageNode',
+  ...overrides,
+});
+
 export const fakeOccurrence = (
   overrides?: Partial<OccurrenceNode>
 ): OccurrenceNode => ({
@@ -311,10 +338,10 @@ export const fakeOccurrence = (
   amountOfSeats: 30,
   minGroupSize: 10,
   maxGroupSize: 20,
-  languages: [
-    { id: 'en', name: 'English', __typename: 'LanguageType' },
-    { id: 'fi', name: 'Finnish', __typename: 'LanguageType' },
-  ] as LanguageType[],
+  languages: fakeLanguages([
+    { id: 'en', name: 'English' },
+    { id: 'fi', name: 'Finnish' },
+  ]),
   startTime: '2020-08-03T09:00:00+00:00',
   endTime: '2020-08-03T09:30:00+00:00',
   placeId: '',

--- a/src/utils/sortFavorably.ts
+++ b/src/utils/sortFavorably.ts
@@ -1,0 +1,12 @@
+/**
+ * Sort favored items in the beginning of the list in given order.
+ * Then sort the rest of the items alphabetically.
+ */
+export default function sortFavorably(sortable: string[], favored: string[]) {
+  favored = [...favored].reverse();
+  return [...sortable].sort((a: string, b: string) => {
+    if (favored.indexOf(a) < favored.indexOf(b)) return 1;
+    if (favored.indexOf(a) > favored.indexOf(b)) return -1;
+    return a < b ? -1 : 1;
+  });
+}


### PR DESCRIPTION
Removed language field from event form, since the event language is now auto populated by API (https://github.com/City-of-Helsinki/palvelutarjotin/pull/131). **This PR needs that API change in order to work properly!**

PT-877 Added new languages to occurrence language selection.

PT-829 PT-857  Event form's basic information (step 1) included an inLanguage field which is now removed, since it is automatically populated with occurrences languages.