### PR TITLE
Improved occurrence form's date field validation

### DIFF
--- a/src/domain/app/i18n/constants.ts
+++ b/src/domain/app/i18n/constants.ts
@@ -1,11 +1,11 @@
 export enum VALIDATION_MESSAGE_KEYS {
   EMAIL = 'form.validation.string.email',
-  NUMBER_MAX = 'form.validation.number.max',
   NUMBER_MIN = 'form.validation.number.min',
+  NUMBER_MAX = 'form.validation.number.max',
   NUMBER_REQUIRED = 'form.validation.number.required',
   STRING_POSITIVENUMBER = 'form.validation.string.positiveNumber',
-  STRING_MAX = 'form.validation.string.max',
   STRING_MIN = 'form.validation.string.min',
+  STRING_MAX = 'form.validation.string.max',
   STRING_REQUIRED = 'form.validation.string.required',
   URL = 'form.validation.string.url',
   DATE_REQUIRED = 'form.validation.date.required',
@@ -15,6 +15,6 @@ export enum VALIDATION_MESSAGE_KEYS {
   DATE_MAX = 'form.validation.date.max',
   TIME = 'form.validation.string.time',
   TIME_MIN = 'form.validation.time.min',
-  TIME_MAX = 'form.validation.time.min',
+  TIME_MAX = 'form.validation.time.max',
   TIME_REQUIRED = 'form.validation.time.required',
 }

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -451,13 +451,13 @@
       "date": {
         "required": "This field is required",
         "mustNotInThePast": "This date must not be in the past",
-        "min": "This date must be after {{min}}",
-        "max": "This date must be before {{max}}"
+        "min": "This date must be earliest {{min}}",
+        "max": "This date must be latest {{max}}"
       },
       "time": {
         "required": "This field is required",
-        "min": "This time must be after {{min}}",
-        "max": "This time must be before {{max}}"
+        "min": "This time must be earliest {{min}}",
+        "max": "This time must be latest {{max}}"
       }
     },
     "actions": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -452,13 +452,13 @@
       "date": {
         "required": "Päivämäärä on pakollinen",
         "mustNotInThePast": "Päivämäärä ei voi olla menneisyydessä",
-        "min": "Päivämäärän on oltava {{min}} jälkeen",
-        "max": "Päivämäärän on oltava ennen {{max}}"
+        "min": "Päivämäärän on oltava aikaisintaan {{min}}",
+        "max": "Päivämäärän on oltava viimeistään {{max}}"
       },
       "time": {
         "required": "Tämä kenttä on pakollinen",
-        "min": "Arvon tulee olla vähintään {{min}}",
-        "max": "Arvon tulee olla enintään {{max}}"
+        "min": "Arvon tulee olla aikaisintaan {{min}}",
+        "max": "Arvon tulee olla viimeistään {{max}}"
       }
     },
     "actions": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -453,13 +453,13 @@
       "date": {
         "required": "Detta fält krävs",
         "mustNotInThePast": "Detta datum kan inte vara i förr",
-        "min": "Detta datum måste vara efter {{min}}",
-        "max": "Detta datum måste vara före {{max}}"
+        "min": "Detta datum måste vara tidigast {{min}}",
+        "max": "Detta datum måste vara senast {{max}}"
       },
       "time": {
         "required": "Detta fält krävs",
-        "min": "Den här tiden måste vara efter {{min}}",
-        "max": "Den här tiden måste vara innan {{max}}"
+        "min": "Den här tiden måste vara tidigast {{min}}",
+        "max": "Den här tiden måste vara senast {{max}}"
       }
     },
     "actions": {

--- a/src/domain/event/eventForm/__tests__/EventForm.test.tsx
+++ b/src/domain/event/eventForm/__tests__/EventForm.test.tsx
@@ -134,7 +134,7 @@ describe('eventForm Tests', () => {
     expect(enrolmentStartInput).toHaveAttribute('aria-describedby');
     expect(
       screen.queryByText(
-        `Päivämäärän on oltava ennen ${currentDateFormatted} 15:00`
+        `Päivämäärän on oltava viimeistään ${currentDateFormatted} 15:00`
       )
     ).toBeInTheDocument();
     userEvent.click(enrolmentStartInput);

--- a/src/domain/occurrence/CreateOccurrencePage.tsx
+++ b/src/domain/occurrence/CreateOccurrencePage.tsx
@@ -11,7 +11,6 @@ import BackButton from '../../common/components/backButton/BackButton';
 import EventSteps from '../../common/components/EventSteps/EventSteps';
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
 import {
-  EventQuery,
   OccurrenceFieldsFragment,
   useAddOccurrenceMutation,
   useDeleteOccurrenceMutation,
@@ -75,7 +74,7 @@ const CreateOccurrencePage: React.FC = () => {
     (item) => !isPast(new Date(item.startTime))
   );
 
-  const initialFormValues = useInitialFormValues(isFirstOccurrence, eventData);
+  const initialFormValues = useInitialFormValues(isFirstOccurrence);
   const { loading: loadingMyProfile } = useMyProfileQuery();
 
   const [createOccurrence] = useAddOccurrenceMutation();
@@ -197,7 +196,7 @@ const CreateOccurrencePage: React.FC = () => {
         isLoading={eventIsInitialLoading || loadingMyProfile}
         hasPadding={false}
       >
-        {eventData ? (
+        {eventData?.event ? (
           <>
             {isEditableEvent(eventData) ? (
               <Container>
@@ -223,7 +222,7 @@ const CreateOccurrencePage: React.FC = () => {
                     />
                   )}
                   <EventOccurrenceForm
-                    eventData={eventData}
+                    event={eventData.event}
                     formTitle={t('createOccurrence.formTitle')}
                     initialValues={initialFormValues}
                     onCancel={goToEventSummary}
@@ -253,10 +252,7 @@ const CreateOccurrencePage: React.FC = () => {
 
 // TODO: maybe could just provide enableReinitialize props form parent component
 // to simplify this. We might not need reinitialization here.
-const useInitialFormValues = (
-  isFirstOccurrence: boolean,
-  eventData: EventQuery | undefined
-) => {
+const useInitialFormValues = (isFirstOccurrence: boolean) => {
   const searcParams = useSearchParams();
 
   const getInitialFormValues = () => {
@@ -265,36 +261,27 @@ const useInitialFormValues = (
     const initialStartsAt = searcParams.get('startsAt');
     const initialEndsAt = searcParams.get('endsAt');
 
-    const initialValues = {
-      ...defaultInitialValues,
-      enrolmentStart: eventData?.event?.pEvent?.enrolmentStart
-        ? new Date(eventData?.event?.pEvent?.enrolmentStart)
-        : null,
-      enrolmentEndDays: eventData?.event?.pEvent?.enrolmentEndDays || 0,
-    };
-
     // if is first occurrence, use pre-filled values from event form (query params)
     if (isFirstOccurrence && initialDate && initialEndsAt && initialStartsAt) {
-      const valuesAreValid =
+      if (
         isValidDate(new Date(initialDate)) &&
         isValidTime(initialStartsAt) &&
-        isValidTime(initialEndsAt);
-
-      if (valuesAreValid) {
-        Object.assign(initialValues, {
+        isValidTime(initialEndsAt)
+      ) {
+        return {
+          ...defaultInitialValues,
           date: new Date(initialDate),
           startsAt: initialStartsAt,
           endsAt: initialEndsAt,
-        });
+        };
       }
     }
-
-    return initialValues;
+    return defaultInitialValues;
   };
 
   // we don't want the initialValues to update because we don't
   // want form to reset to those on subsequent renders
-  return React.useMemo(getInitialFormValues, [eventData]);
+  return React.useMemo(getInitialFormValues, []);
 };
 
 export default CreateOccurrencePage;

--- a/src/domain/occurrence/EditOccurrencePage.tsx
+++ b/src/domain/occurrence/EditOccurrencePage.tsx
@@ -206,8 +206,10 @@ const EditOccurrencePage: React.FC = () => {
       hasAreaForGroupWork: venueData?.venue?.hasAreaForGroupWork || false,
       hasIndoorPlayingArea: venueData?.venue?.hasIndoorPlayingArea || false,
       hasOutdoorPlayingArea: venueData?.venue?.hasOutdoorPlayingArea || false,
+      enrolmentStart: eventData?.event?.pEvent.enrolmentStart || null,
+      enrolmentEndDays: eventData?.event?.pEvent.enrolmentEndDays || 0,
     }),
-    [locale, occurrenceData, venueData]
+    [eventData, locale, occurrenceData, venueData]
   );
 
   return (

--- a/src/domain/occurrence/EditOccurrencePage.tsx
+++ b/src/domain/occurrence/EditOccurrencePage.tsx
@@ -206,10 +206,8 @@ const EditOccurrencePage: React.FC = () => {
       hasAreaForGroupWork: venueData?.venue?.hasAreaForGroupWork || false,
       hasIndoorPlayingArea: venueData?.venue?.hasIndoorPlayingArea || false,
       hasOutdoorPlayingArea: venueData?.venue?.hasOutdoorPlayingArea || false,
-      enrolmentStart: eventData?.event?.pEvent.enrolmentStart || null,
-      enrolmentEndDays: eventData?.event?.pEvent.enrolmentEndDays || 0,
     }),
-    [eventData, locale, occurrenceData, venueData]
+    [locale, occurrenceData, venueData]
   );
 
   return (
@@ -217,7 +215,7 @@ const EditOccurrencePage: React.FC = () => {
       <LoadingSpinner
         isLoading={loadingEvent || loadingOccurrence || loadingVenue}
       >
-        {eventData && occurrenceData ? (
+        {eventData?.event && occurrenceData ? (
           <>
             {isEditableEvent(eventData) ? (
               <Container>
@@ -229,14 +227,14 @@ const EditOccurrencePage: React.FC = () => {
                   </BackButton>
                   <div className={styles.headerContainer}>
                     <h1>
-                      {getLocalizedString(eventData?.event?.name || {}, locale)}
+                      {getLocalizedString(eventData.event.name || {}, locale)}
                     </h1>
                     <Button variant="secondary" onClick={goToEventDetailsPage}>
                       {t('editOccurrence.buttonShowEventInfo')}
                     </Button>
                   </div>
                   <EventOccurrenceForm
-                    eventData={eventData}
+                    event={eventData.event}
                     formTitle={t('editOccurrence.formTitle')}
                     initialValues={initialValues}
                     occurrenceId={occurrenceId}

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -4,6 +4,7 @@ import { advanceTo, clear } from 'jest-date-mock';
 import range from 'lodash/range';
 import * as React from 'react';
 
+import { DATE_FORMAT } from '../../../common/components/datepicker/contants';
 import * as graphql from '../../../generated/graphql';
 import { runCommonEventFormTests } from '../../../utils/CommonEventFormTests';
 import {
@@ -17,6 +18,7 @@ import {
   fakeVenue,
 } from '../../../utils/mockDataUtils';
 import {
+  fireEvent,
   renderWithRoute,
   screen,
   userEvent,
@@ -37,8 +39,18 @@ const placeMock = fakePlace({
 });
 const venueMock = fakeVenue();
 
-const initializeMocks = (fromDate = new Date(2020, 7, 2), occurrences = 5) => {
+const initializeMocks = (
+  fromDate = new Date(2020, 7, 2),
+  occurrences = 5,
+  enrolmentStart = null,
+  enrolmentEndDays = 3
+) => {
   advanceTo(fromDate);
+
+  const pEventOverrides = {
+    enrolmentStart: enrolmentStart || fromDate,
+    enrolmentEndDays,
+  };
 
   const occurrenceFormData = {
     date: '13.08.2020',
@@ -72,6 +84,7 @@ const initializeMocks = (fromDate = new Date(2020, 7, 2), occurrences = 5) => {
               fakeOccurrenceOverrides.length,
               fakeOccurrenceOverrides
             ),
+            ...pEventOverrides,
           }),
         },
       },
@@ -133,13 +146,15 @@ afterEach(() => {
 const initializeMocksAndRenderPage = (
   renderOptions,
   fromDate = new Date(2020, 7, 2),
+  enrolmentStart = fromDate,
+  enrolmentEndDays = 0,
   occurrences = 5
 ) => {
   const {
     fakeOccurrenceOverrides,
     occurrenceFormData,
     apolloMocks,
-  } = initializeMocks(fromDate, occurrences);
+  } = initializeMocks(fromDate, occurrences, enrolmentStart, enrolmentEndDays);
   renderWithRoute(<CreateOccurrencePage />, {
     mocks: apolloMocks,
     ...renderOptions,
@@ -357,16 +372,20 @@ test('does not initializes values from URL if they are invalid', async () => {
 });
 
 describe('common event form tests', () => {
-  runCommonEventFormTests((currentDate: Date) => {
-    initializeMocksAndRenderPage(
-      {
-        routes: [ROUTES.CREATE_OCCURRENCE.replace(':id', eventMock.id)],
-        path: ROUTES.CREATE_OCCURRENCE,
-      },
-      currentDate,
-      1
-    );
-  });
+  runCommonEventFormTests(
+    (currentDate: Date, enrolmentStart: Date, enrolmentEndDays = 0) => {
+      initializeMocksAndRenderPage(
+        {
+          routes: [ROUTES.CREATE_OCCURRENCE.replace(':id', eventMock.id)],
+          path: ROUTES.CREATE_OCCURRENCE,
+        },
+        currentDate,
+        enrolmentStart,
+        enrolmentEndDays,
+        1
+      );
+    }
+  );
 });
 
 test('when only one group checkbox is checked, amount of seats should be disabled', async () => {
@@ -385,4 +404,41 @@ test('when only one group checkbox is checked, amount of seats should be disable
     expect(seatsCountInput).toHaveValue(1);
   });
   expect(seatsCountInput).toBeDisabled();
+});
+
+test('occurrence date cannot be before enrolments ending day', async () => {
+  const currentDate = new Date('2008-08-01');
+  advanceTo(currentDate);
+
+  initializeMocksAndRenderPage(
+    {
+      routes: [ROUTES.CREATE_OCCURRENCE.replace(':id', eventMock.id)],
+      path: ROUTES.CREATE_OCCURRENCE,
+    },
+    currentDate,
+    currentDate,
+    2
+  );
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+  });
+
+  expect(
+    screen.queryByTestId('eventOccurrenceForm-infoText2')
+  ).toHaveTextContent(
+    'mahdollista 01.08.2008 jälkeen ja sulkeutuu 2 päivää ennen tapahtuma-ajan alkua.'
+  );
+
+  const dateInput = screen.getByRole('textbox', { name: 'Päivämäärä' });
+  userEvent.click(dateInput);
+  userEvent.type(dateInput, format(currentDate, DATE_FORMAT));
+  fireEvent.blur(dateInput);
+  await waitFor(() => {
+    expect(dateInput).toBeInvalid();
+  });
+  expect(dateInput).toHaveAttribute('aria-describedby');
+  expect(
+    screen.queryByText('Päivämäärän on oltava aikaisintaan 03.08.2008')
+  ).toBeInTheDocument();
 });

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -430,6 +430,10 @@ test('occurrence date cannot be before enrolments ending day', async () => {
     'mahdollista 01.08.2008 jälkeen ja sulkeutuu 2 päivää ennen tapahtuma-ajan alkua.'
   );
 
+  expect(
+    screen.queryByText('Päivämäärän on oltava aikaisintaan 03.08.2008')
+  ).not.toBeInTheDocument();
+
   const dateInput = screen.getByRole('textbox', { name: 'Päivämäärä' });
   userEvent.click(dateInput);
   userEvent.type(dateInput, format(currentDate, DATE_FORMAT));

--- a/src/domain/occurrence/eventOccurrenceForm/EventOccurrenceForm.tsx
+++ b/src/domain/occurrence/eventOccurrenceForm/EventOccurrenceForm.tsx
@@ -42,6 +42,8 @@ export const defaultInitialValues: OccurrenceFormFields = {
   hasAreaForGroupWork: false,
   hasIndoorPlayingArea: false,
   hasOutdoorPlayingArea: false,
+  enrolmentStart: null,
+  enrolmentEndDays: 0,
 };
 
 interface Props {
@@ -188,6 +190,7 @@ const EventOccurrenceForm: React.FC<Props & GoToPublishingProps> = ({
                   <FormGroup>
                     {/* TODO: Get real values from api when implemented */}
                     <p
+                      data-testid="eventOccurrenceForm-infoText2"
                       dangerouslySetInnerHTML={{
                         __html: t('eventOccurrenceForm.infoText2', {
                           date: eventData.event?.pEvent?.enrolmentStart

--- a/src/domain/occurrence/eventOccurrenceForm/EventOccurrenceForm.tsx
+++ b/src/domain/occurrence/eventOccurrenceForm/EventOccurrenceForm.tsx
@@ -2,7 +2,6 @@ import { Field, Formik, FormikHelpers } from 'formik';
 import { Button } from 'hds-react';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { DateSchema } from 'yup';
 
 import CheckboxField from '../../../common/components/form/fields/CheckboxField';
 import DateInputField from '../../../common/components/form/fields/DateInputField';
@@ -23,9 +22,7 @@ import PlaceInfo from '../../place/placeInfo/PlaceInfo';
 import VenueDataFields from '../../venue/venueDataFields/VenueDataFields';
 import { OccurrenceFormFields } from '../types';
 import styles from './eventOccurrenceForm.module.scss';
-import ValidationSchema, {
-  testDateWithEnrolmentValidationSchema,
-} from './ValidationSchema';
+import { getValidationSchema } from './ValidationSchema';
 
 export const defaultInitialValues: OccurrenceFormFields = {
   date: null,
@@ -116,12 +113,7 @@ const EventOccurrenceForm: React.FC<Props & GoToPublishingProps> = ({
   }, [t]);
 
   const validationSchema = React.useMemo(
-    () =>
-      testDateWithEnrolmentValidationSchema(
-        ValidationSchema.fields.date as DateSchema,
-        event?.pEvent,
-        ValidationSchema
-      ),
+    () => getValidationSchema(event?.pEvent),
     [event]
   );
 

--- a/src/domain/occurrence/eventOccurrenceForm/ValidationSchema.ts
+++ b/src/domain/occurrence/eventOccurrenceForm/ValidationSchema.ts
@@ -1,8 +1,10 @@
+import addDays from 'date-fns/addDays';
 import isBefore from 'date-fns/isBefore';
 import parseDate from 'date-fns/parse';
 import * as Yup from 'yup';
 
 import { isTodayOrLater, isValidTime } from '../../../utils/dateUtils';
+import formatDate from '../../../utils/formatDate';
 import { VALIDATION_MESSAGE_KEYS } from '../../app/i18n/constants';
 
 const addMinValidationMessage = (
@@ -31,6 +33,25 @@ export default Yup.object().shape({
       'isTodayOrInTheFuture',
       VALIDATION_MESSAGE_KEYS.DATE_IN_THE_FUTURE,
       isTodayOrLater
+    )
+    .when(
+      ['enrolmentStart', 'enrolmentEndDays'],
+      (
+        enrolmentStart: Date,
+        enrolmentEndDays: number,
+        schema: Yup.DateSchema
+      ) => {
+        if (!enrolmentStart || !(enrolmentStart instanceof Date)) return schema;
+        const minDate =
+          enrolmentEndDays > 0
+            ? addDays(enrolmentStart, enrolmentEndDays)
+            : enrolmentStart;
+        minDate.setHours(0, 0, 0, 0);
+        return schema.min(minDate, () => ({
+          key: VALIDATION_MESSAGE_KEYS.DATE_MIN,
+          min: formatDate(minDate),
+        }));
+      }
     ),
   startsAt: Yup.string()
     .required(VALIDATION_MESSAGE_KEYS.TIME_REQUIRED)

--- a/src/domain/occurrence/types.ts
+++ b/src/domain/occurrence/types.ts
@@ -10,4 +10,6 @@ export interface OccurrenceFormFields extends VenueDataFields {
   maxGroupSize: string;
   minGroupSize: string;
   oneGroupFills: boolean;
+  enrolmentStart: Date | null;
+  enrolmentEndDays: number;
 }

--- a/src/domain/occurrence/types.ts
+++ b/src/domain/occurrence/types.ts
@@ -10,6 +10,4 @@ export interface OccurrenceFormFields extends VenueDataFields {
   maxGroupSize: string;
   minGroupSize: string;
   oneGroupFills: boolean;
-  enrolmentStart: Date | null;
-  enrolmentEndDays: number;
 }

--- a/src/utils/CommonEventFormTests.ts
+++ b/src/utils/CommonEventFormTests.ts
@@ -5,7 +5,11 @@ import { DATE_FORMAT } from '../common/components/datepicker/contants';
 import { fireEvent, screen, userEvent, waitFor } from './testUtils';
 
 export const runCommonEventFormTests = (
-  renderForm: (currentDate: Date) => void
+  renderForm: (
+    currentDate: Date,
+    enrolmentStart: Date,
+    enrolmentEndDays: number
+  ) => void
 ) => {
   describe('Common event form tests', () => {
     afterAll(() => {
@@ -15,7 +19,7 @@ export const runCommonEventFormTests = (
     it('yesterday is not valid event start day', async () => {
       const currentDate = new Date('2008-08-01');
       advanceTo(currentDate);
-      renderForm(currentDate);
+      renderForm(currentDate, currentDate, 0);
 
       await waitFor(() => {
         expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
@@ -37,7 +41,7 @@ export const runCommonEventFormTests = (
     it('today is valid event start day', async () => {
       const currentDate = new Date(2020, 7, 2);
       advanceTo(currentDate);
-      renderForm(currentDate);
+      renderForm(currentDate, currentDate, 0);
 
       await waitFor(() => {
         expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();


### PR DESCRIPTION
PT-481 Occurrence's date is validated against pEvent.enrolmentStart and pEvent.enrolmentEndDays fields.

Submitted as a draft, since this branch is basing on PR #156. It's still a ready implementation.

It would be nice to get improvement suggestions for passing the 2 new pEvent variables to occurrence validation. Now they are passed via occurrence form model.