### PR TITLE
PT-896, PT-771, PT-412 | Better helping texts and mandatory keywords

### DIFF
--- a/src/common/components/form/fields/MultiDropdownField.tsx
+++ b/src/common/components/form/fields/MultiDropdownField.tsx
@@ -67,7 +67,8 @@ const MultiDropdownField: React.FC<Props> = ({
     <Select
       {...rest}
       {...field}
-      helper={errorText || helper}
+      helper={helper}
+      error={errorText}
       invalid={Boolean(errorText)}
       multiselect={true}
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -294,6 +294,7 @@
       "labelInfoUrl": "A web address where you can find more information about the event",
       "labelName": "Event name",
       "labelShortDescription": "Short description (up to 160 characters)",
+      "helperEnrolmentEndDays": "Select how many days before occurrences enrolment ends",
       "photographer": "Photographer",
       "title": "Basic information"
     },
@@ -306,7 +307,7 @@
       "occurrenceTimeHelperText": "First occurrence date. Rest of the occurrences and additional information are entered in step 2."
     },
     "categorisation": {
-      "helperKeywords": "Enter a keyword and select from the suggested options",
+      "helperKeywords": "Enter a keyword and choose from the options",
       "labelCategories": "Categories",
       "labelActivities": "Activities",
       "labelAudience": "Target groups",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -295,6 +295,7 @@
       "labelInfoUrl": "WWW-osoite, josta saa lisätietoja tapahtumasta",
       "labelName": "Tapahtuman nimi",
       "labelShortDescription": "Lyhyt kuvaus (korkeintaan 160 merkkiä)",
+      "helperEnrolmentEndDays": "Valitse kuinka monta päivää ennen tapahtuma-aikaa ilmoittautuminen päättyy",
       "photographer": "Valokuvaaja",
       "title": "Tapahtuman perustiedot"
     },
@@ -307,7 +308,7 @@
       "occurrenceTimeHelperText": "Ensimmäinen tapahtuma-aika. Loput tapahtuma-ajat ja niiden lisätiedot syötetään vaiheessa 2."
     },
     "categorisation": {
-      "helperKeywords": "Kirjoita asiasana ja valitse ehdotetuista vaihtoehdoista",
+      "helperKeywords": "Kirjoita asiasana ja valitse vaihtoehdoista",
       "labelCategories": "Kategoriat",
       "labelActivities": "Aktiviteetit",
       "labelAudience": "Kohderyhmät",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -296,6 +296,7 @@
       "labelName": "Evenemang namn",
       "labelShortDescription": "Kort beskrivning",
       "labelTargetGroup": "Målgrupper",
+      "helperEnrolmentEndDays": "Välj hur många dagar innan händelsetiden anmälan slutar",
       "photographer": "Fotograf",
       "title": "Grundläggande information"
     },
@@ -308,7 +309,7 @@
       "occurrenceTimeHelperText": "Första förekomstdatum. Resten av händelserna och ytterligare information anges i steg 2."
     },
     "categorisation": {
-      "helperKeywords": "Ange ett nyckelord och välj bland de föreslagna alternativen",
+      "helperKeywords": "Skriv ett nyckelord och välj bland de alternativen",
       "labelCategories": "Kategorier",
       "labelActivities": "Aktiviteter",
       "labelAudience": "Målgrupper",

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -300,6 +300,9 @@ const EventForm = <T extends FormFields>({
                             labelText={t(
                               'eventForm.basicInfo.labelEnrolmentEndDays'
                             )}
+                            helperText={t(
+                              'eventForm.basicInfo.helperEnrolmentEndDays'
+                            )}
                             required
                             name="enrolmentEndDays"
                             component={TextInputField}
@@ -327,6 +330,7 @@ const EventForm = <T extends FormFields>({
                       <div data-testid="audience-dropdown">
                         <FormGroup>
                           <Field
+                            required
                             component={MultiDropdownField}
                             label={t('eventForm.categorisation.labelAudience')}
                             name="audience"
@@ -346,6 +350,7 @@ const EventForm = <T extends FormFields>({
                       <div data-testid="categories-dropdown">
                         <FormGroup>
                           <Field
+                            required
                             component={MultiDropdownField}
                             label={t(
                               'eventForm.categorisation.labelCategories'
@@ -369,6 +374,7 @@ const EventForm = <T extends FormFields>({
                       <div data-testid="additional-criteria-dropdown">
                         <FormGroup>
                           <Field
+                            required
                             component={MultiDropdownField}
                             label={t(
                               'eventForm.categorisation.labelActivities'
@@ -399,7 +405,6 @@ const EventForm = <T extends FormFields>({
                               'eventForm.categorisation.labelKeywords'
                             )}
                             name="keywords"
-                            required
                             placeholder={t(
                               'eventForm.categorisation.placeholderKeywords'
                             )}

--- a/src/domain/event/eventForm/ValidationSchema.ts
+++ b/src/domain/event/eventForm/ValidationSchema.ts
@@ -72,9 +72,16 @@ const createValidationSchemaYup = (
         min: param.min,
         key: VALIDATION_MESSAGE_KEYS.NUMBER_MIN,
       })),
-    keywords: Yup.array()
+    audience: Yup.array()
       .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
       .min(0),
+    categories: Yup.array()
+      .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
+      .min(0),
+    additionalCriteria: Yup.array()
+      .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
+      .min(0),
+    keywords: Yup.array().min(0),
     location: Yup.string().required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED),
     // providerContactInfo: Yup.object().shape({
     //   email: Yup.string().email(VALIDATION_MESSAGE_KEYS.EMAIL),

--- a/src/domain/event/eventForm/__tests__/EventForm.test.tsx
+++ b/src/domain/event/eventForm/__tests__/EventForm.test.tsx
@@ -18,7 +18,7 @@ import {
   userEvent,
   waitFor,
 } from '../../../../utils/testUtils';
-import EventForm, { defaultInitialValues } from '../EventForm';
+import EventForm, { createEventInitialValues } from '../EventForm';
 
 afterAll(() => {
   clear();
@@ -38,7 +38,7 @@ const renderForm = () =>
     <EventForm
       title="Testilomake"
       persons={[]}
-      initialValues={defaultInitialValues}
+      initialValues={createEventInitialValues}
       onCancel={jest.fn()}
       selectedLanguage="fi"
       onSubmit={jest.fn()}

--- a/src/domain/occurrence/__tests__/OccurrenceDetailsPage.test.tsx
+++ b/src/domain/occurrence/__tests__/OccurrenceDetailsPage.test.tsx
@@ -111,8 +111,6 @@ const occurrenceResult = {
   },
 };
 
-// console.log(JSON.stringify(occurrenceResult, null, 2));
-
 const mocks = [
   {
     request: {

--- a/src/test/apollo-mocks/keywordSetMocks.ts
+++ b/src/test/apollo-mocks/keywordSetMocks.ts
@@ -1,0 +1,49 @@
+import { MockedResponse } from '@apollo/react-testing';
+
+import {
+  KeywordSet,
+  KeywordSetDocument,
+  KeywordSetQueryVariables,
+  KeywordSetType,
+} from '../../generated/graphql';
+import {
+  fakeKeyword,
+  fakeKeywordSet,
+  fakeLocalizedObject,
+} from '../../utils/mockDataUtils';
+
+const getKeywordSetMockResponse = ({
+  variables = { setType: KeywordSetType.Category },
+  keywordSet = fakeKeywordSet(),
+}: {
+  variables: Partial<KeywordSetQueryVariables>;
+  keywordSet: KeywordSet;
+}): MockedResponse => ({
+  request: {
+    query: KeywordSetDocument,
+    variables,
+  },
+  result: {
+    data: { keywordSet },
+  },
+});
+
+const getKeywordSetsMockResponses = (
+  keywordSetMocks: {
+    setType: KeywordSetType;
+    keywords: { id: string; name: string }[];
+  }[]
+): MockedResponse[] => {
+  return keywordSetMocks.map(({ setType, keywords }) =>
+    getKeywordSetMockResponse({
+      variables: { setType },
+      keywordSet: fakeKeywordSet({
+        keywords: keywords.map((k) =>
+          fakeKeyword({ id: k.id, name: fakeLocalizedObject(k.name) })
+        ),
+      }),
+    })
+  );
+};
+
+export { getKeywordSetsMockResponses };

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -313,7 +313,7 @@ export const fakeOccurrenceNodeEdge = (
 export const fakeLanguages = (
   languages?: Partial<LanguageNode>[]
 ): LanguageNodeConnection => ({
-  edges: languages.map((language) => fakeLanguageNodeEdge(language)),
+  edges: languages?.map((language) => fakeLanguageNodeEdge(language)) || [],
   pageInfo: PageInfoMock,
   __typename: 'LanguageNodeConnection',
 });

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import faker from 'faker';
 
+import { LINKEDEVENTS_CONTENT_TYPE } from '../constants';
 import {
   EnrolmentNode,
   EnrolmentNodeConnection,
@@ -39,6 +40,7 @@ import {
   StudyLevelNodeEdge,
   VenueNode,
 } from '../generated/graphql';
+import getLinkedEventsInternalId from './getLinkedEventsInternalId';
 
 const organizationNames = [
   'Kulttuuri- ja vapaa-aikalautakunnan kulttuurijaosto',
@@ -210,13 +212,19 @@ export const fakeKeywords = (count = 1, keywords?: Partial<Keyword>[]) => ({
   __typename: 'KeywordsListResponse',
 });
 
-export const fakeKeyword = (overrides?: Partial<Keyword>): Keyword => ({
-  id: faker.random.uuid(),
-  name: fakeLocalizedObject(),
-  internalId: 'https://api.hel.fi/linkedevents-test/v1/keyword/yso:p4363/',
-  __typename: 'Keyword',
-  ...overrides,
-});
+export const fakeKeyword = (overrides?: Partial<Keyword>): Keyword => {
+  const id = overrides?.id || faker.random.uuid();
+  return {
+    id: faker.random.uuid(),
+    name: fakeLocalizedObject(),
+    internalId: getLinkedEventsInternalId(
+      LINKEDEVENTS_CONTENT_TYPE.KEYWORD,
+      id
+    ),
+    __typename: 'Keyword',
+    ...overrides,
+  };
+};
 
 export const fakeVenue = (overrides?: Partial<VenueNode>): VenueNode => ({
   id: faker.random.uuid(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
   "exclude": [
     "src/**/*.stories.*",
     "**/*.test.*",
+    "src/test/**",
     "src/utils/testUtils.tsx",
     "src/utils/mockDataUtils.ts",
     "src/utils/CommonEventFormTests.ts"


### PR DESCRIPTION
## Description :sparkles:

- Update some helper texts in event form
- Make target groups, categories and activities required in event form
- Delete requirement from keywords

## Issues :bug:
### Closes :no_good_woman:
**[PT-896](https://helsinkisolutionoffice.atlassian.net/browse/PT-896):** 
**[PT-771](https://helsinkisolutionoffice.atlassian.net/browse/PT-772):** 
**[PT-412](https://helsinkisolutionoffice.atlassian.net/browse/PT-412):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: