### PR TITLE
Use common language translations everywhere.

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -70,11 +70,6 @@
     "labelIsSameResponsiblePerson": "Same as notifier",
     "labelIsSharingDataAccepted": "I agree to share my information with the event organizer",
     "labelLanguage": "Language",
-    "language": {
-      "en": "English",
-      "fi": "Finnish",
-      "sv": "Swedish"
-    },
     "person": {
       "labelEmailAddress": "Email address",
       "labelName": "Name",
@@ -542,11 +537,7 @@
     "textAmountOfGroups": "{{count}} group",
     "textAmountOfGroups_plural": "{{count}} groups",
     "textGroupInfo": "group size {{minGroupSize}}–{{maxGroupSize}}",
-    "languages": {
-      "en": "in English",
-      "fi": "in Finnish",
-      "sv": "in Swedish"
-    }
+    "labelLanguages": "Language"
   },
   "occurrences": {
     "actionsDropdown": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -47,12 +47,12 @@
       "buttonClose": "Sulje"
     },
     "languages": {
-      "ar": "Arabia",
-      "en": "Englanti",
-      "fi": "Suomi",
-      "ru": "Venäjä",
-      "sv": "Ruotsi",
-      "zh_hans": "Kiina"
+      "ar": "arabia",
+      "en": "englanti",
+      "fi": "suomi",
+      "ru": "venäjä",
+      "sv": "ruotsi",
+      "zh_hans": "kiina"
     },
     "tableDropdown": {
       "toggleButton": "Valitse"
@@ -543,11 +543,7 @@
     "textAmountOfGroups_plural": "{{count}} ryhmää",
     "textAmountOfSeats_plural": "{{count}} paikkaa",
     "textGroupInfo": "ryhmän koko {{minGroupSize}}–{{maxGroupSize}}",
-    "languages": {
-      "en": "englanninkielinen",
-      "fi": "suomenkielinen",
-      "sv": "ruotsinkielinen"
-    }
+    "labelLanguages": "Kieli"
   },
   "occurrences": {
     "actionsDropdown": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -544,11 +544,7 @@
     "textAmountOfGroups": "{{count}} grupp",
     "textAmountOfGroups_plural": "{{count}} grupper",
     "textGroupInfo": "gruppstorlek {{minGroupSize}}–{{maxGroupSize}}",
-    "languages": {
-      "en": "engelsk",
-      "fi": "finska",
-      "sv": "svenska"
-    }
+    "labelLanguages": "Språk"
   },
   "occurrences": {
     "actionsDropdown": {

--- a/src/domain/enrolment/__tests__/EditEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/EditEnrolmentPage.test.tsx
@@ -167,7 +167,7 @@ it('initializes edit form correctly', async () => {
     screen.queryByLabelText(messages.enrolmentForm.labelLanguage, {
       selector: 'button',
     })
-  ).toHaveTextContent('Suomi');
+  ).toHaveTextContent('suomi');
 
   expect(
     screen.queryByLabelText(messages.enrolmentForm.studyGroup.labelExtraNeeds)

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -60,7 +60,7 @@ const EnrolmentForm: React.FC<Props> = ({
   const { options: studyLevelOptions } = useStudyLevels();
 
   const languageOptions = Object.values(Language).map((level) => ({
-    label: translateValue('enrolmentForm.language.', level, t),
+    label: translateValue('common.languages.', level, t),
     value: level,
   }));
 

--- a/src/domain/event/__tests__/CreateEventPage.test.tsx
+++ b/src/domain/event/__tests__/CreateEventPage.test.tsx
@@ -385,7 +385,7 @@ test('modal opens when trying to change language', async () => {
   });
 
   // should open modal when trying to change event language
-  userEvent.click(screen.getByRole('button', { name: 'Ruotsi' }));
+  userEvent.click(screen.getByRole('button', { name: 'ruotsi' }));
   expect(screen.getByRole('dialog')).toHaveTextContent(/vaihda kieli/i);
 
   const modal = within(screen.getByRole('dialog', {}));

--- a/src/domain/event/__tests__/EventDetailsPage.test.tsx
+++ b/src/domain/event/__tests__/EventDetailsPage.test.tsx
@@ -138,7 +138,9 @@ test('renders correct information and delete works', async () => {
   });
 
   // Suomi language is active
-  expect(screen.getByText('Suomi').parentElement).toHaveClass('isSelected');
+  expect(screen.getByTestId('eventLanguageSelector-suomi')).toHaveClass(
+    'isSelected'
+  );
 
   expect(
     screen.queryByRole('heading', { name: 'Testitapahtuma' })

--- a/src/domain/event/editEventButtons/__tests__/__snapshots__/EditEventButtons.test.tsx.snap
+++ b/src/domain/event/editEventButtons/__tests__/__snapshots__/EditEventButtons.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`matches snapshot 1`] = `
     >
       <button
         class="languageButton isSelected"
+        data-testid="eventLanguageSelector-suomi"
         type="button"
       >
         <div
@@ -78,11 +79,12 @@ exports[`matches snapshot 1`] = `
           </svg>
         </div>
         <span>
-          Suomi
+          suomi
         </span>
       </button>
       <button
         class="languageButton"
+        data-testid="eventLanguageSelector-ruotsi"
         type="button"
       >
         <div
@@ -110,11 +112,12 @@ exports[`matches snapshot 1`] = `
           </svg>
         </div>
         <span>
-          Ruotsi
+          ruotsi
         </span>
       </button>
       <button
         class="languageButton"
+        data-testid="eventLanguageSelector-englanti"
         type="button"
       >
         <div
@@ -142,7 +145,7 @@ exports[`matches snapshot 1`] = `
           </svg>
         </div>
         <span>
-          Englanti
+          englanti
         </span>
       </button>
     </div>

--- a/src/domain/event/eventDetailsButtons/__test__/EventDetailsButtons.test.tsx
+++ b/src/domain/event/eventDetailsButtons/__test__/EventDetailsButtons.test.tsx
@@ -65,7 +65,7 @@ test('it renders correct texts and click events work', () => {
   });
 
   expect(screen.queryByText('Tapahtumat')).toBeVisible();
-  expect(screen.queryByText('Suomi')).toBeVisible();
-  expect(screen.queryByText('Englanti')).toBeVisible();
-  expect(screen.queryByText('Ruotsi')).toBeVisible();
+  expect(screen.queryByText('suomi')).toBeVisible();
+  expect(screen.queryByText('englanti')).toBeVisible();
+  expect(screen.queryByText('ruotsi')).toBeVisible();
 });

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -228,9 +228,6 @@ const EventForm = <T extends FormFields>({
                         labelText={t(
                           'eventForm.basicInfo.labelMandatoryAdditionalInformation'
                         )}
-                        helperText={t(
-                          'eventForm.basicInfo.guidanceTextMandatoryAdditionalInformation'
-                        )}
                         name="mandatoryAdditionalInformation"
                         component={CheckboxField}
                       />
@@ -308,9 +305,6 @@ const EventForm = <T extends FormFields>({
                             labelText={t(
                               'eventForm.basicInfo.labelEnrolmentEndDays'
                             )}
-                            helperText={t(
-                              'eventForm.basicInfo.helperEnrolmentEndDays'
-                            )}
                             required
                             name="enrolmentEndDays"
                             component={TextInputField}
@@ -338,7 +332,6 @@ const EventForm = <T extends FormFields>({
                       <div data-testid="audience-dropdown">
                         <FormGroup>
                           <Field
-                            required
                             component={MultiDropdownField}
                             label={t('eventForm.categorisation.labelAudience')}
                             name="audience"
@@ -358,7 +351,6 @@ const EventForm = <T extends FormFields>({
                       <div data-testid="categories-dropdown">
                         <FormGroup>
                           <Field
-                            required
                             component={MultiDropdownField}
                             label={t(
                               'eventForm.categorisation.labelCategories'
@@ -382,7 +374,6 @@ const EventForm = <T extends FormFields>({
                       <div data-testid="additional-criteria-dropdown">
                         <FormGroup>
                           <Field
-                            required
                             component={MultiDropdownField}
                             label={t(
                               'eventForm.categorisation.labelActivities'
@@ -413,6 +404,7 @@ const EventForm = <T extends FormFields>({
                               'eventForm.categorisation.labelKeywords'
                             )}
                             name="keywords"
+                            required
                             placeholder={t(
                               'eventForm.categorisation.placeholderKeywords'
                             )}

--- a/src/domain/event/eventLanguageSelector/EventLanguageSelector.tsx
+++ b/src/domain/event/eventLanguageSelector/EventLanguageSelector.tsx
@@ -29,7 +29,8 @@ const EventLanguageSelector: React.FC<Props> = ({
         const isSelected = language.value === selectedLanguage;
         return (
           <button
-            key={index}
+            key={`eventLanguageSelector-${index}`}
+            data-testid={`eventLanguageSelector-${language.label}`}
             className={classNames(styles.languageButton, {
               [styles.isDisabled]: language.isDisabled,
               [styles.isSelected]: isSelected,

--- a/src/domain/occurrence/__tests__/EditOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/EditOccurrencePage.test.tsx
@@ -209,8 +209,8 @@ test('initializes edit occurrence form correctly', async () => {
   expect(screen.getByLabelText('Ryhmäkoko max')).toHaveValue(20);
 
   const dropdown = within(screen.getByTestId('language-dropdown'));
-  expect(dropdown.queryByText('Suomi')).toBeInTheDocument();
-  expect(dropdown.queryByText('Englanti')).toBeInTheDocument();
+  expect(dropdown.queryByText('suomi')).toBeInTheDocument();
+  expect(dropdown.queryByText('englanti')).toBeInTheDocument();
 
   await waitFor(() => {
     expect(screen.queryByText('Testikatu')).toBeInTheDocument();

--- a/src/domain/occurrence/__tests__/OccurrenceDetailsPage.test.tsx
+++ b/src/domain/occurrence/__tests__/OccurrenceDetailsPage.test.tsx
@@ -188,10 +188,9 @@ test('occurrence details are rendered', async () => {
     screen.queryByText('10.09.2020 klo 12:00 – 12:30')
   ).toBeInTheDocument();
   expect(
-    screen.queryByText(
-      '30 paikkaa, ryhmän koko 10–20, suomenkielinen, englanninkielinen'
-    )
+    screen.queryByText('30 paikkaa, ryhmän koko 10–20')
   ).toBeInTheDocument();
+  expect(screen.queryByText('Kieli: suomi, englanti')).toBeInTheDocument();
 
   expect(
     screen.queryByRole('button', { name: 'Näytä tapahtuman tiedot' })

--- a/src/domain/occurrence/occurrenceGroupInfo/OccurrenceGroupInfo.tsx
+++ b/src/domain/occurrence/occurrenceGroupInfo/OccurrenceGroupInfo.tsx
@@ -13,9 +13,6 @@ interface Props {
 const OccurrenceGroupInfo: React.FC<Props> = ({ occurrence }) => {
   const { t } = useTranslation();
 
-  const languages = occurrence.languages.edges.map(
-    (edge) => edge?.node?.id || ''
-  );
   const amountOfSeats = occurrence.amountOfSeats;
   const maxGroupSize = occurrence.maxGroupSize;
   const minGroupSize = occurrence.minGroupSize;
@@ -31,9 +28,6 @@ const OccurrenceGroupInfo: React.FC<Props> = ({ occurrence }) => {
       maxGroupSize,
       minGroupSize,
     }),
-    languages
-      ?.map((language) => t(`occurrenceDetails.languages.${language}`))
-      .join(', '),
   ]
     .filter((e) => e)
     .join(', ');

--- a/src/domain/occurrence/occurrenceGroupInfo/OccurrenceGroupLanguageInfo.tsx
+++ b/src/domain/occurrence/occurrenceGroupInfo/OccurrenceGroupLanguageInfo.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { OccurrenceFieldsFragment } from '../../../generated/graphql';
+
+interface Props {
+  occurrence: OccurrenceFieldsFragment;
+}
+
+const OccurrenceGroupLanguageInfo: React.FC<Props> = ({ occurrence }) => {
+  const { t } = useTranslation();
+
+  const languages =
+    occurrence.languages.edges.map((edge) => edge?.node?.id ?? '') ?? [];
+
+  return (
+    <p>
+      {t('occurrenceDetails.labelLanguages')}:{' '}
+      {languages
+        ?.map((language) => t(`common.languages.${language}`))
+        .join(', ')}
+    </p>
+  );
+};
+
+export default OccurrenceGroupLanguageInfo;

--- a/src/domain/occurrence/occurrenceInfo/OccurrenceInfo.tsx
+++ b/src/domain/occurrence/occurrenceInfo/OccurrenceInfo.tsx
@@ -16,6 +16,7 @@ import { getEventFields } from '../../event/utils';
 import { PUBLICATION_STATUS } from '../../events/constants';
 import PlaceInfo from '../../place/placeInfo/PlaceInfo';
 import OccurrenceGroupInfo from '../occurrenceGroupInfo/OccurrenceGroupInfo';
+import OccurrenceGroupLanguageInfo from '../occurrenceGroupInfo/OccurrenceGroupLanguageInfo';
 import styles from './occurrenceInfo.module.scss';
 
 interface Props {
@@ -72,6 +73,10 @@ const OccurrenceInfo: React.FC<Props> = ({ event, occurrence }) => {
           <IconUser />
         </div>
         <OccurrenceGroupInfo occurrence={occurrence} />
+      </div>
+      <div className={styles.infoRow}>
+        <div className={styles.iconWrapper}></div>
+        <OccurrenceGroupLanguageInfo occurrence={occurrence} />
       </div>
       <div className={styles.infoRow}>
         <div className={styles.iconWrapper}>


### PR DESCRIPTION
PT-908. Using only 1 common language translation instead of 3 different ones, which content is still the same. Helps maintaining the code and the translations.  Also added  a new component named OccurrenceGroupLanguageInfo, which is having the same behavior that the component in palvelutarjotin-ui repo.

![image](https://user-images.githubusercontent.com/389204/112167922-876b3600-8bf9-11eb-8ffb-8eaaad3c8bd0.png)


![image](https://user-images.githubusercontent.com/389204/112167851-73bfcf80-8bf9-11eb-957a-8ffdc27c7773.png)


![image](https://user-images.githubusercontent.com/389204/112167972-94882500-8bf9-11eb-8890-aef9c40cfcf9.png)
