### PR TITLE
PT-647 | Add virtual event checkbox to event form

### DIFF
--- a/src/common/components/form/fields/PlaceSelectorField.tsx
+++ b/src/common/components/form/fields/PlaceSelectorField.tsx
@@ -13,6 +13,7 @@ interface Props extends FieldProps {
   labelText: string;
   placeholder?: string;
   required?: boolean;
+  disabled: boolean;
 }
 
 const PlaceSelectorField: React.FC<Props> = (props) => {
@@ -25,6 +26,7 @@ const PlaceSelectorField: React.FC<Props> = (props) => {
     helperText,
     labelText,
     placeholder,
+    disabled,
   } = props;
   const invalidText = getErrorText(errors, touched, name, t);
 
@@ -49,6 +51,7 @@ const PlaceSelectorField: React.FC<Props> = (props) => {
   return (
     <PlaceSelector
       {...field}
+      disabled={disabled}
       id={name}
       invalidText={invalidText}
       helperText={helperText}

--- a/src/domain/event/EditEventPage.tsx
+++ b/src/domain/event/EditEventPage.tsx
@@ -22,6 +22,7 @@ import { PUBLICATION_STATUS } from '../events/constants';
 import { getImageName } from '../image/utils';
 import ActiveOrganisationInfo from '../organisation/activeOrganisationInfo/ActiveOrganisationInfo';
 import { createOrUpdateVenue } from '../venue/utils';
+import { VIRTUAL_EVENT_LOCATION_ID } from './constants';
 import EventForm, { defaultInitialValues } from './eventForm/EventForm';
 import styles from './eventPage.module.scss';
 import { EventFormFields } from './types';
@@ -184,6 +185,15 @@ const EditEventPage: React.FC = () => {
     setSelectedLanguage(newLanguage);
   };
 
+  const getLocationId = (locationId: string | undefined | null): string => {
+    // If location id is virtual event location, we are not going to show it as location.
+    // Only virtual location checkbox should be checked.
+    if (locationId !== VIRTUAL_EVENT_LOCATION_ID) {
+      return locationId ?? '';
+    }
+    return '';
+  };
+
   React.useEffect(() => {
     if (eventData) {
       setInitialValues({
@@ -214,7 +224,7 @@ const EditEventPage: React.FC = () => {
           eventData.event?.offers?.[0]?.description?.[selectedLanguage] || '',
         keywords:
           getRealKeywords(eventData)?.map((keyword) => keyword.id || '') || [],
-        location: eventData.event?.location?.id || '',
+        location: getLocationId(eventData.event?.location.id),
         name: eventData.event?.name[selectedLanguage] || '',
         neededOccurrences:
           eventData.event?.pEvent?.neededOccurrences.toString() || '',
@@ -240,6 +250,7 @@ const EditEventPage: React.FC = () => {
         autoAcceptance: eventData.event?.pEvent.autoAcceptance,
         mandatoryAdditionalInformation:
           eventData.event?.pEvent?.mandatoryAdditionalInformation || false,
+        isVirtual: eventData.event?.location.id === VIRTUAL_EVENT_LOCATION_ID,
       });
     }
   }, [eventData, selectedLanguage]);

--- a/src/domain/event/__tests__/EditEventPage.test.tsx
+++ b/src/domain/event/__tests__/EditEventPage.test.tsx
@@ -214,57 +214,74 @@ const updateEventResponse = {
   },
 };
 
+const editEventVariables = {
+  event: {
+    id: eventId,
+    name: { fi: 'TestitapahtumaTestinimi' },
+    startTime: '2020-08-04T21:00:00.000Z',
+    endTime: '',
+    offers: [
+      {
+        description: {
+          fi: 'description',
+        },
+        price: {
+          fi: '99,9',
+        },
+        isFree: true,
+      },
+    ],
+    shortDescription: { fi: shortDescription },
+    description: { fi: description },
+    images: [{ internalId: '/image/48598/' }],
+    infoUrl: { fi: infoUrl },
+    audience: audienceKeywords.map((k) => ({
+      internalId: getKeywordId(k.id),
+    })),
+    inLanguage: [
+      { internalId: '/language/fi/' },
+      { internalId: '/language/en/' },
+    ],
+    keywords: [
+      {
+        internalId: getKeywordId(keywordId),
+      },
+      ...basicKeywords.map((k) => ({ internalId: getKeywordId(k.id) })),
+    ],
+    location: { internalId: `/place/${placeId}/` },
+    pEvent: {
+      contactEmail: contactEmail,
+      contactPersonId: contactPersonId,
+      contactPhoneNumber: contactPhoneNumber,
+      enrolmentEndDays: 3,
+      enrolmentStart: '2020-08-13T00:45:00.000Z',
+      neededOccurrences: 3,
+      autoAcceptance: true,
+      mandatoryAdditionalInformation: false,
+    },
+    organisationId: personId,
+    draft: true,
+  },
+};
+
 const mocks = [
+  {
+    request: {
+      query: EditEventDocument,
+      variables: editEventVariables,
+    },
+    result: updateEventResponse,
+  },
   {
     request: {
       query: EditEventDocument,
       variables: {
         event: {
-          id: eventId,
-          name: { fi: 'TestitapahtumaTestinimi' },
-          startTime: '2020-08-04T21:00:00.000Z',
-          endTime: '',
-          offers: [
-            {
-              description: {
-                fi: 'description',
-              },
-              price: {
-                fi: '99,9',
-              },
-              isFree: true,
-            },
-          ],
-          shortDescription: { fi: shortDescription },
-          description: { fi: description },
-          images: [{ internalId: '/image/48598/' }],
-          infoUrl: { fi: infoUrl },
-          audience: audienceKeywords.map((k) => ({
-            internalId: getKeywordId(k.id),
-          })),
-          inLanguage: [
-            { internalId: '/language/fi/' },
-            { internalId: '/language/en/' },
-          ],
-          keywords: [
-            {
-              internalId: getKeywordId(keywordId),
-            },
-            ...basicKeywords.map((k) => ({ internalId: getKeywordId(k.id) })),
-          ],
-          location: { internalId: `/place/${placeId}/` },
-          pEvent: {
-            contactEmail: contactEmail,
-            contactPersonId: contactPersonId,
-            contactPhoneNumber: contactPhoneNumber,
-            enrolmentEndDays: 3,
-            enrolmentStart: '2020-08-13T00:45:00.000Z',
-            neededOccurrences: 3,
-            autoAcceptance: true,
-            mandatoryAdditionalInformation: false,
+          ...editEventVariables.event,
+          name: { fi: 'Testitapahtuma' },
+          location: {
+            internalId: '/place/helsinki:internet/',
           },
-          organisationId: personId,
-          draft: true,
         },
       },
     },
@@ -284,9 +301,7 @@ const mocks = [
     request: {
       query: MyProfileDocument,
     },
-    result: {
-      ...profileResponse,
-    },
+    result: profileResponse,
   },
   {
     request: {
@@ -393,6 +408,43 @@ test('edit event form initializes and submits correctly', async () => {
     expect(
       screen.queryByText('Sivulla on tallentamattomia muutoksia')
     ).toBeInTheDocument();
+  });
+
+  userEvent.click(
+    screen.getByRole('button', {
+      name: 'Tallenna',
+    })
+  );
+
+  await waitFor(() => {
+    expect(goBack).toHaveBeenCalled();
+  });
+});
+
+test('virtual event checkbox works correctly', async () => {
+  const { history } = render(<EditEventPage />, { mocks });
+
+  const goBack = jest.spyOn(history, 'goBack');
+
+  expect(screen.queryByTestId('loading-spinner')).toBeInTheDocument();
+
+  await waitFor(() => {
+    expect(screen.queryByText(organizationName)).toBeInTheDocument();
+  });
+
+  await waitFor(() => {
+    expect(screen.getAllByText('Sellon kirjasto')).toHaveLength(2);
+  });
+
+  userEvent.click(
+    screen.getByRole('checkbox', {
+      name: /tapahtuma järjestetään virtuaalisesti/i,
+    })
+  );
+
+  // Location shouldn't be shown after virtual event checkbox has been clicked
+  await waitFor(() => {
+    expect(screen.queryByText('Sellon kirjasto')).not.toBeInTheDocument();
   });
 
   userEvent.click(

--- a/src/domain/event/constants.ts
+++ b/src/domain/event/constants.ts
@@ -9,3 +9,5 @@ export const EVENT_PLACEHOLDER_IMAGES = [
   imgPlaceholderC,
   imgPlaceholderD,
 ];
+
+export const VIRTUAL_EVENT_LOCATION_ID = 'helsinki:internet';

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -29,6 +29,7 @@ import ImageSelectedFormPart from './ImageSelectedFormPart';
 import SelectImageFormPart from './SelectImageFormPart';
 import { useKeywordOptions } from './useKeywordOptions';
 import createValidationSchema, { createEventSchema } from './ValidationSchema';
+import VirtualEventCheckboxField from './VirtualEventCheckboxField';
 
 export const defaultInitialValues: EventFormFields = {
   audience: [],
@@ -63,6 +64,7 @@ export const defaultInitialValues: EventFormFields = {
   hasIndoorPlayingArea: false,
   hasOutdoorPlayingArea: false,
   autoAcceptance: true,
+  isVirtual: false,
 };
 
 export const createEventInitialValues: CreateEventFormFields = {
@@ -159,8 +161,8 @@ const EventForm = <T extends FormFields>({
         touched,
       }) => {
         const { contactPersonId, image, location, isFree } = values;
-
         const imageSelected = Boolean(image);
+
         return (
           <>
             <FocusToFirstError />
@@ -227,9 +229,6 @@ const EventForm = <T extends FormFields>({
                       <Field
                         labelText={t(
                           'eventForm.basicInfo.labelMandatoryAdditionalInformation'
-                        )}
-                        helperText={t(
-                          'eventForm.basicInfo.guidanceTextMandatoryAdditionalInformation'
                         )}
                         name="mandatoryAdditionalInformation"
                         component={CheckboxField}
@@ -470,7 +469,7 @@ const EventForm = <T extends FormFields>({
                         labelText={t('eventForm.offers.labelPriceDescription')}
                         name="priceDescription"
                         component={TextAreaInputField}
-                        placeHolder={t(
+                        placeholder={t(
                           'eventForm.offers.placeholderPriceDescription'
                         )}
                         rows={20}
@@ -486,10 +485,10 @@ const EventForm = <T extends FormFields>({
                       labelText={t('eventForm.location.labelLocation')}
                       name="location"
                       required
+                      disabled={values.isVirtual}
                       placeholder={t('eventForm.location.placeholderLocation')}
                       component={PlaceSelectorField}
                     />
-
                     {location && (
                       <>
                         <div className={styles.placeInfoContainer}>
@@ -505,6 +504,13 @@ const EventForm = <T extends FormFields>({
                         />
                       </>
                     )}
+                    <div className={styles.isVirtualCheckbox}>
+                      <Field
+                        labelText="Tapahtuma järjestetään virtuaalisesti"
+                        name="isVirtual"
+                        component={VirtualEventCheckboxField}
+                      />
+                    </div>
                   </div>
 
                   <div className={styles.formSection}>

--- a/src/domain/event/eventForm/ValidationSchema.ts
+++ b/src/domain/event/eventForm/ValidationSchema.ts
@@ -82,11 +82,12 @@ const createValidationSchemaYup = (
       .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
       .min(0),
     keywords: Yup.array().min(0),
-    location: Yup.string().required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED),
-    // providerContactInfo: Yup.object().shape({
-    //   email: Yup.string().email(VALIDATION_MESSAGE_KEYS.EMAIL),
-    //   name: Yup.string().required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED),
-    // }),
+    location: Yup.string().when('isVirtual', {
+      is: false,
+      then: Yup.string().required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED),
+      otherwise: Yup.string(),
+    }),
+    isVirtual: Yup.boolean(),
     image: Yup.string(),
     imagePhotographerName: Yup.string().when('image', {
       is: (image) => image,

--- a/src/domain/event/eventForm/VirtualEventCheckboxField.tsx
+++ b/src/domain/event/eventForm/VirtualEventCheckboxField.tsx
@@ -1,0 +1,26 @@
+import { FieldProps } from 'formik';
+import { CheckboxProps } from 'hds-react';
+import * as React from 'react';
+
+import CheckboxField from '../../../common/components/form/fields/CheckboxField';
+
+// This is its own component because how Formik recommends to handle situations
+// where form value is based on other form value.
+// see: https://github.com/formium/formik/issues/2204#issuecomment-574207100
+const VirtualEventCheckboxField = ({
+  form,
+  ...props
+}: FieldProps & CheckboxProps) => {
+  const { value: isVirtual } = props.field;
+  const { setFieldValue } = form;
+
+  React.useEffect(() => {
+    if (isVirtual) {
+      setFieldValue('location', '');
+    }
+  }, [isVirtual, setFieldValue]);
+
+  return <CheckboxField {...props} form={form} />;
+};
+
+export default VirtualEventCheckboxField;

--- a/src/domain/event/eventForm/eventForm.module.scss
+++ b/src/domain/event/eventForm/eventForm.module.scss
@@ -40,6 +40,10 @@
     }
   }
 
+  .isVirtualCheckbox {
+    margin-top: var(--spacing-s);
+  }
+
   .neededOccurrencesRow {
     display: grid;
     grid-gap: var(--grid-gap);

--- a/src/domain/event/types.ts
+++ b/src/domain/event/types.ts
@@ -34,6 +34,7 @@ export interface EventFormFields extends VenueDataFields {
   autoAcceptance?: boolean;
   categories: string[];
   additionalCriteria: string[];
+  isVirtual: boolean;
 }
 
 export interface FirstOccurrenceFields {

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -19,7 +19,10 @@ import getLinkedEventsInternalId from '../../utils/getLinkedEventsInternalId';
 import getLocalisedString from '../../utils/getLocalizedString';
 import getTimeFormat from '../../utils/getTimeFormat';
 import { PUBLICATION_STATUS } from '../events/constants';
-import { EVENT_PLACEHOLDER_IMAGES } from './constants';
+import {
+  EVENT_PLACEHOLDER_IMAGES,
+  VIRTUAL_EVENT_LOCATION_ID,
+} from './constants';
 import { CreateEventFormFields, EventFormFields } from './types';
 
 /**
@@ -167,7 +170,8 @@ export const getEventPayload = ({
     location: {
       internalId: getLinkedEventsInternalId(
         LINKEDEVENTS_CONTENT_TYPE.PLACE,
-        values.location
+        // If event is virtual, we use location id for internet events
+        values.isVirtual ? VIRTUAL_EVENT_LOCATION_ID : values.location
       ),
     },
     pEvent: {

--- a/src/domain/place/PlaceSelector.tsx
+++ b/src/domain/place/PlaceSelector.tsx
@@ -28,6 +28,7 @@ interface Props {
   placeholder?: string;
   value: string | string[];
   required?: boolean;
+  disabled: boolean;
 }
 
 const optionLabelToString = (option: AutoSuggestOption, locale: Language) => {
@@ -50,6 +51,7 @@ const PlaceSelector: React.FC<Props> = ({
   placeholder,
   value,
   required,
+  disabled,
 }) => {
   const [inputValue, setInputValue] = React.useState('');
   const searchValue = useDebounce(inputValue, 100);
@@ -115,6 +117,7 @@ const PlaceSelector: React.FC<Props> = ({
     <AutoSuggest
       className={className}
       helperText={helperText}
+      disabled={disabled}
       id={id}
       required={required}
       inputValue={inputValue}


### PR DESCRIPTION
## Description :sparkles:

- Add virtual event checkbox

## Issues :bug:
### Closes :no_good_woman:
**[PT-647](https://helsinkisolutionoffice.atlassian.net/browse/PT-647):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

<img width="991" alt="Screenshot 2021-03-29 at 10 43 29" src="https://user-images.githubusercontent.com/15219142/112803129-a34c5d00-907b-11eb-97b5-3db93a6a92ed.png">
<img width="1058" alt="Screenshot 2021-03-29 at 10 43 25" src="https://user-images.githubusercontent.com/15219142/112803135-a47d8a00-907b-11eb-8ef9-b3467eb19ea1.png">



## Additional notes :spiral_notepad: