### PR TITLE
PT-1019 | Add more instructions to delete event modal

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -262,6 +262,7 @@
       "buttonDelete": "Delete event",
       "text1": "Are you sure you want to delete the event?",
       "text2": "Once deleted, events can not be restored.",
+      "sendNotificationWarning": "Before you delete the event, please remember to send a cancellation notice to those who has enrolled.",
       "title": "Delete event",
       "upcomingOccurrences": "Upcoming occurrences",
       "occurrenceTime": "{{date}} at {{time}}"

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -267,6 +267,7 @@
       "buttonDelete": "Poista tapahtuma",
       "text1": "Oletko varma että haluat poistaa tapahtuman?",
       "text2": "Poistettua tapahtumaa ei voi palauttaa.",
+      "sendNotificationWarning": "Muista lähettää ilmoittautuneille peruutusviesti, ennen kuin poistat tapahtuman!",
       "title": "Poista tapahtuma",
       "upcomingOccurrences": "Tulevat tapahtuma-ajat",
       "occurrenceTime": "{{date}} klo {{time}}"

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -267,6 +267,7 @@
       "buttonDelete": "Bort evenemang",
       "text1": "Är du säker på att du vill ta bort evenemang?",
       "text2": "En borttagen evenemang kan inte ångras.",
+      "sendNotificationWarning": "Glöm inte att skicka meddelande om avbeställning till de som anmält sig, innan du raderar evenemanget!",
       "title": "Bort evenemang",
       "upcomingOccurrences": "Kommande händelser",
       "occurrenceTime": "{{date}} kl. {{time}}"

--- a/src/domain/event/EventDetailsPage.tsx
+++ b/src/domain/event/EventDetailsPage.tsx
@@ -135,7 +135,7 @@ const EventDetailsPage = () => {
                 toggleModal={toggleModal}
               >
                 <p>{t('eventDetails.deleteModal.text1')}</p>
-                <p>{t('eventDetails.deleteModal.text2')}</p>
+                <p>{t('eventDetails.deleteModal.sendNotificationWarning')}</p>
                 {renderFutureOccurrencesList()}
               </AlertModal>
 

--- a/src/domain/event/__tests__/EventDetailsPage.test.tsx
+++ b/src/domain/event/__tests__/EventDetailsPage.test.tsx
@@ -176,6 +176,15 @@ test('renders correct information and delete works', async () => {
     modal.queryByText('Poista tapahtuma', { selector: 'div' })
   ).toBeInTheDocument();
 
+  const modalTexts = [
+    /Muista lähettää ilmoittautuneille peruutusviesti, ennen kuin poistat tapahtuman/i,
+    /Oletko varma että haluat poistaa tapahtuman/i,
+  ];
+
+  modalTexts.forEach((t) => {
+    expect(modal.queryByText(t)).toBeInTheDocument();
+  });
+
   userEvent.click(modal.getByRole('button', { name: 'Poista tapahtuma' }));
 
   expect(deleteMock).toHaveBeenCalledWith({


### PR DESCRIPTION
## Description :sparkles:

- Add more instructions to delete event modal

## Issues :bug:
### Closes :no_good_woman:
**[PT-1019](https://helsinkisolutionoffice.atlassian.net/browse/PT-1019):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

<img width="791" alt="Screenshot 2021-05-10 at 9 42 50" src="https://user-images.githubusercontent.com/15219142/117616775-3d6fec80-b174-11eb-9aaa-25f350756c6b.png">


## Additional notes :spiral_notepad: