### PR TITLE
PT-1026 | Add cancel action to occurrences table in summary page

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -604,7 +604,11 @@
       "note2": "Enrolments to this occurrence will be canceled and a message will be sent to enrollees."
     },
     "cancelError": "Canceling occurrence failed",
+    "cancelErrorSuccess": "Occurrence canceled",
     "pageTitle": "Event times",
+    "status": {
+      "cancelled": "Cancelled"
+    },
     "table": {
       "columnActions": "Actions",
       "columnAmountOfSeats": "Seats",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -605,12 +605,16 @@
       "title": "Poista tapahtuma-aika"
     },
     "cancelModal": {
-      "title": "Cancel occurrence",
+      "title": "Peruuta tapahtuma-aika",
       "note1": "Oletko varma, että haluat poistaa valitun tapahtuma-ajan?",
       "note2": "Tähän tapahtuma-aikaan ilmoittautuneiden ilmoittautumiset perutaan ja heille lähetetään peruutusviesti"
     },
     "cancelError": "Tapahtuma-ajan peruminen epäonnistui",
+    "cancelErrorSuccess": "Tapahtuma-aika peruutettu",
     "pageTitle": "Tapahtuma-ajat",
+    "status": {
+      "cancelled": "Peruttu"
+    },
     "table": {
       "columnActions": "Toiminnot",
       "columnAmountOfSeats": "Paikkoja",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -606,12 +606,16 @@
       "title": "Bort evenemangtid"
     },
     "cancelModal": {
-      "title": "Cancel occurrence",
+      "title": "Avbryt förekomst",
       "note1": "Är du säker på att du vill ta bort den valda förekomsten?",
       "note2": "Anmälningar till denna händelse avbryts och ett meddelande skickas till anmälda."
     },
     "cancelError": "Det gick inte att avbryta förekomsten",
+    "cancelErrorSuccess": "Tiden för händelsen avbröts",
     "pageTitle": "Evenemangtider",
+    "status": {
+      "cancelled": "Inställt"
+    },
     "table": {
       "columnActions": "Funktioner",
       "columnAmountOfSeats": "Platser",

--- a/src/domain/occurrences/occurrencesTable/ActionsDropdown.tsx
+++ b/src/domain/occurrences/occurrencesTable/ActionsDropdown.tsx
@@ -14,8 +14,8 @@ import CancelOccurrenceModal from './CancelOccurrenceModal';
 
 export interface Props {
   eventId: string;
-  isEventDraft: boolean;
-  onDelete: (row: OccurrenceFieldsFragment) => void;
+  isEventDraft?: boolean;
+  onDelete?: (row: OccurrenceFieldsFragment) => void;
   onCancel?: (row: OccurrenceFieldsFragment, message?: string) => void;
   row: OccurrenceFieldsFragment;
 }
@@ -62,7 +62,7 @@ const ActionsDropdown: React.FC<Props> = ({
   };
 
   const handleDelete = () => {
-    onDelete(row);
+    onDelete?.(row);
     toggleModal();
   };
 

--- a/src/domain/occurrences/occurrencesTableReadOnly/OccurrencesTableSummary.tsx
+++ b/src/domain/occurrences/occurrencesTableReadOnly/OccurrencesTableSummary.tsx
@@ -15,16 +15,19 @@ import formatTimeRange from '../../../utils/formatTimeRange';
 import { ROUTES } from '../../app/routes/constants';
 import PlaceText from '../../place/PlaceText';
 import EnrolmentsBadge from '../enrolmentsBadge/EnrolmentsBadge';
+import ActionsDropdown from '../occurrencesTable/ActionsDropdown';
 import styles from './occurrencesTableSummary.module.scss';
 
 export interface Props {
   eventData?: EventQuery;
   occurrences: OccurrenceFieldsFragment[];
+  onCancel?: (occurrence: OccurrenceFieldsFragment, message?: string) => void;
 }
 
 const OccurrencesTableSummary: React.FC<Props> = ({
   eventData,
   occurrences,
+  onCancel,
 }) => {
   const { t } = useTranslation();
   const history = useHistory();
@@ -92,6 +95,13 @@ const OccurrencesTableSummary: React.FC<Props> = ({
         </>
       ),
       accessor: (row: OccurrenceFieldsFragment) => {
+        if (row.cancelled) {
+          return (
+            <span className={styles.cancelledText}>
+              {t('occurrences.status.cancelled')}
+            </span>
+          );
+        }
         if (row.seatsTaken != null && row.seatsApproved != null) {
           return (
             <EnrolmentsBadge
@@ -104,6 +114,14 @@ const OccurrencesTableSummary: React.FC<Props> = ({
         return null;
       },
       id: 'enrolments',
+    },
+    {
+      Header: t('occurrences.table.columnActions'),
+      accessor: (row: OccurrenceFieldsFragment) => (
+        <ActionsDropdown eventId={eventId} onCancel={onCancel} row={row} />
+      ),
+      id: 'actions',
+      rowClickDisabled: true,
     },
   ];
 

--- a/src/domain/occurrences/occurrencesTableReadOnly/__tests__/OccurrencesTableSummary.test.tsx
+++ b/src/domain/occurrences/occurrencesTableReadOnly/__tests__/OccurrencesTableSummary.test.tsx
@@ -41,7 +41,7 @@ it('show occurrence data in the table in correct format', () => {
   expect(screen.getByText(/240/i)).toBeInTheDocument();
   // row text to check the order of columns
   const occurrenceRowText =
-    '11.12.2020 00:00 – 00:00 - 240 0 hyväksytty 0 hyväksymättä';
+    '11.12.2020 00:00 – 00:00 - 240 0 hyväksytty 0 hyväksymättä Valitse';
   const occurrenceRow = screen.getByRole('row', {
     name: occurrenceRowText,
   });

--- a/src/domain/occurrences/occurrencesTableReadOnly/occurrencesTableSummary.module.scss
+++ b/src/domain/occurrences/occurrencesTableReadOnly/occurrencesTableSummary.module.scss
@@ -6,3 +6,9 @@
 .enrolmentsInfoText {
   font-size: var(--fontsize-body-s);
 }
+
+.cancelledText {
+  background-color: var(--color-engel);
+  padding: var(--spacing-3-xs) var(--spacing-xs);
+  display: inline-block;
+}

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -3,6 +3,7 @@ import { AnyAction, Store } from '@reduxjs/toolkit';
 import { fireEvent, render, RenderResult } from '@testing-library/react';
 import { createMemoryHistory, History } from 'history';
 import * as React from 'react';
+import Modal from 'react-modal';
 import { Provider } from 'react-redux';
 import { Route, Router } from 'react-router-dom';
 
@@ -65,6 +66,7 @@ const renderWithRoute: CustomRender = (
   );
 
   const renderResult = render(ui, { wrapper: Wrapper });
+  Modal.setAppElement(renderResult.container);
   return { ...renderResult, history };
 };
 


### PR DESCRIPTION
## Description :sparkles:

- Add cancel action to occurrences table
- Show badge if occurrence is cancelled

## Issues :bug:
### Closes :no_good_woman:
**[PT-1026](https://helsinkisolutionoffice.atlassian.net/browse/PT-1026):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

<img width="1035" alt="Screenshot 2021-05-12 at 20 12 17" src="https://user-images.githubusercontent.com/15219142/118016821-86839480-b35e-11eb-999d-6f9174cc34c7.png">


## Additional notes :spiral_notepad: