### PR TITLE
Added download events' enrolments button to event summary page.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,7 @@
 REACT_APP_API_URI=https://palvelutarjotin-api.test.kuva.hel.ninja/graphql
 
+REACT_APP_API_REPORT_URI=https://palvelutarjotin-api.test.kuva.hel.ninja/reports
+
 REACT_APP_LINKEDEVENTS_API_URI=https://api.hel.fi/linkedevents-test/v1
 
 REACT_APP_OIDC_AUTHORITY=https://tunnistamo.test.kuva.hel.ninja

--- a/src/clients/apiReportClient/apiReportClient.ts
+++ b/src/clients/apiReportClient/apiReportClient.ts
@@ -1,23 +1,23 @@
 import axios from 'axios';
 
-// import { store } from '../../domain/app/store';
-// import { apiTokenSelector } from '../../domain/auth/selectors';
+import { store } from '../../domain/app/store';
+import { apiTokenSelector } from '../../domain/auth/selectors';
 
 const axiosClient = axios.create({
   baseURL: `${process.env.REACT_APP_API_REPORT_URI}`,
   timeout: 30000,
 });
 
-// axiosClient.interceptors.request.use(
-//   (config) => {
-//     const token = apiTokenSelector(store.getState());
-//     if (token) {
-//       config.headers.Authorization = `Bearer ${token}`;
-//     }
-//     return config;
-//   },
-//   (error) => Promise.reject(error)
-// );
+axiosClient.interceptors.request.use(
+  (config) => {
+    const token = apiTokenSelector(store.getState());
+    if (token) {
+      config.headers.authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
 
 export enum ROUTES {
   EVENTS_ENROLMENTS = '/palvelutarjotinevent/enrolments/csv/',

--- a/src/clients/apiReportClient/apiReportClient.ts
+++ b/src/clients/apiReportClient/apiReportClient.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+
+// import { store } from '../../domain/app/store';
+// import { apiTokenSelector } from '../../domain/auth/selectors';
+
+const axiosClient = axios.create({
+  baseURL: `${process.env.REACT_APP_API_REPORT_URI}`,
+  timeout: 30000,
+});
+
+// axiosClient.interceptors.request.use(
+//   (config) => {
+//     const token = apiTokenSelector(store.getState());
+//     if (token) {
+//       config.headers.Authorization = `Bearer ${token}`;
+//     }
+//     return config;
+//   },
+//   (error) => Promise.reject(error)
+// );
+
+export enum ROUTES {
+  EVENTS_ENROLMENTS = '/palvelutarjotinevent/enrolments/csv/',
+}
+
+export default axiosClient;

--- a/src/clients/apiReportClient/useReportClientQuery.ts
+++ b/src/clients/apiReportClient/useReportClientQuery.ts
@@ -1,0 +1,40 @@
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
+
+import apiReportClient, { ROUTES } from './apiReportClient';
+
+function useDownloadEventsEnrolmentsCsvQuery(pEventId: string | undefined) {
+  const { t } = useTranslation();
+  if (!pEventId) return undefined;
+  return async () => {
+    const filename = `kultus_events_approved_enrolments.csv`;
+    const response = await apiReportClient.get(
+      `${ROUTES.EVENTS_ENROLMENTS}?ids=${pEventId}`,
+      {
+        responseType: 'blob',
+        headers: {
+          'Content-Type': 'text/csv',
+          Accept: 'text/csv; charset=utf-8',
+          // 'Content-Disposition': `attachment; filename=${filename}`,
+        },
+      }
+    );
+    // Hack to download files with axios:
+    // https://gist.github.com/javilobo8/097c30a233786be52070986d8cdb1743
+    if (response.status === 200 && response?.data?.type === 'text/csv') {
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', filename);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } else {
+      toast(t('eventEnrolmentsReport.downloadError'), {
+        type: toast.TYPE.ERROR,
+      });
+    }
+  };
+}
+
+export { useDownloadEventsEnrolmentsCsvQuery };

--- a/src/clients/apiReportClient/useReportClientQuery.ts
+++ b/src/clients/apiReportClient/useReportClientQuery.ts
@@ -13,8 +13,10 @@ function useDownloadEventsEnrolmentsCsvQuery(pEventId: string | undefined) {
       {
         responseType: 'blob',
         headers: {
-          'Content-Type': 'text/csv',
-          Accept: 'text/csv; charset=utf-8',
+          'Content-Type': 'text/csv; charset=utf-8',
+          /* TODO: Accept and Content-Disposition headers would be good to have, 
+          but they won't work until API supports them. */
+          // Accept: 'text/csv; charset=utf-8',
           // 'Content-Disposition': `attachment; filename=${filename}`,
         },
       }
@@ -22,19 +24,26 @@ function useDownloadEventsEnrolmentsCsvQuery(pEventId: string | undefined) {
     // Hack to download files with axios:
     // https://gist.github.com/javilobo8/097c30a233786be52070986d8cdb1743
     if (response.status === 200 && response?.data?.type === 'text/csv') {
-      const url = window.URL.createObjectURL(new Blob([response.data]));
-      const link = document.createElement('a');
-      link.href = url;
-      link.setAttribute('download', filename);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
+      downloadFile(response.data, filename);
     } else {
       toast(t('eventEnrolmentsReport.downloadError'), {
         type: toast.TYPE.ERROR,
       });
     }
   };
+}
+
+/**
+ * A browser hack to download a file instead of just a byte string.
+ */
+function downloadFile(data: string, filename: string) {
+  const url = window.URL.createObjectURL(new Blob([data]));
+  const link = document.createElement('a');
+  link.href = url;
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
 }
 
 export { useDownloadEventsEnrolmentsCsvQuery };

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -414,7 +414,11 @@
     "titleEventSummary": "Event summary",
     "titleEventSummaryHelper": "Click to go to event preview",
     "buttonEditBasicInfo": "Edit basic info",
-    "buttonEditOccurrences": "Edit occurrences"
+    "buttonEditOccurrences": "Edit occurrences",
+    "buttonExportEnrolments": "Download enrolments (CSV)"
+  },
+  "eventEnrolmentsReport": {
+    "downloadError": "Error while downloading the CSV file."
   },
   "createOccurrence": {
     "buttonBack": "Back to basic info",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -420,7 +420,11 @@
     "titleEventSummary": "Tapahtuman esikatselu",
     "titleEventSummaryHelper": "Klikkaa koko tapahtuman esikatseluun",
     "buttonEditBasicInfo": "Muokkaa perustietoja",
-    "buttonEditOccurrences": "Muokkaa tapahtuma-aikoja"
+    "buttonEditOccurrences": "Muokkaa tapahtuma-aikoja",
+    "buttonExportEnrolments": "Lataa ilmoittautumiset (CSV)"
+  },
+  "eventEnrolmentsReport": {
+    "downloadError": "Virhe ladattaessa CSV-tiedostoa."
   },
   "createOccurrence": {
     "buttonBack": "Takaisin perustietoihin",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -421,7 +421,11 @@
     "titleEventSummary": "Sammanfattning av händelser",
     "titleEventSummaryHelper": "Klicka för att gå till händelseförhandsgranskning",
     "buttonEditBasicInfo": "Edit basic info",
-    "buttonEditOccurrences": "Redigera förekomster"
+    "buttonEditOccurrences": "Redigera förekomster",
+    "buttonExportEnrolments": "Ladda ner registreringar (CSV)"
+  },
+  "eventEnrolmentsReport": {
+    "downloadError": "Ett fel uppstod när filen laddades."
   },
   "createOccurrence": {
     "buttonBack": "Tillbaka till grundläggande information",

--- a/src/domain/app/routes/constants.ts
+++ b/src/domain/app/routes/constants.ts
@@ -15,6 +15,7 @@ export enum ROUTES {
   OCCURRENCES = '/events/:id/occurrences',
   OCCURRENCE_DETAILS = '/events/:id/occurrences/:occurrenceId',
   SILENT_CALLBACK = '/silent-callback',
+  ENROLMENT_REPORT = '/events/:id/export-enrolments',
 }
 
 export const IGNORE_SCROLL_TO_TOP = [

--- a/src/domain/event/EventSummaryPage.tsx
+++ b/src/domain/event/EventSummaryPage.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router';
 
+import { useDownloadEventsEnrolmentsCsvQuery } from '../../clients/apiReportClient/useReportClientQuery';
 import BackButton from '../../common/components/backButton/BackButton';
 import EditButton from '../../common/components/editButton/EditButton';
 import EventSteps from '../../common/components/EventSteps/EventSteps';
@@ -38,11 +39,13 @@ const EventSummaryPage: React.FC = () => {
   const { id: eventId } = useParams<Params>();
   const locale = useLocale();
   const [showAllPastEvents, setShowAllPastEvents] = React.useState(false);
-
   const { data: eventData, loading } = useEventQuery({
     fetchPolicy: 'network-only',
     variables: { id: eventId, include: ['location', 'keywords'] },
   });
+  const downloadEnrolmentsQuery = useDownloadEventsEnrolmentsCsvQuery(
+    eventData?.event?.pEvent?.id
+  );
 
   const organisationId = eventData?.event?.pEvent?.organisation?.id || '';
   const isEventDraft =
@@ -80,6 +83,11 @@ const EventSummaryPage: React.FC = () => {
   };
 
   const goToHome = () => history.push(ROUTES.HOME);
+
+  // Export CSV file from API reports view
+  const downloadEnrolments = () => {
+    downloadEnrolmentsQuery && downloadEnrolmentsQuery();
+  };
 
   const getEditLink = () => {
     const searchParams = new URLSearchParams();
@@ -155,6 +163,11 @@ const EventSummaryPage: React.FC = () => {
                       })}
                     </span>
                   </h2>
+                  {!isEventDraft && (
+                    <Button onClick={downloadEnrolments} variant="secondary">
+                      {t('eventSummary.buttonExportEnrolments')}
+                    </Button>
+                  )}
                   {isEventDraft && (
                     <EditButton
                       text={t('eventSummary.buttonEditOccurrences')}


### PR DESCRIPTION
PT-1024 PT-1032. Added apiReportClient which is implemented with Axios. When the API does not return csv file, toast is thrown. Events' enrolments csv file can be downloaded when API does not require authentication.