### PR TITLE
Submit occurrence form if needed when saving enrolment form data

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -425,7 +425,8 @@
     "occurrences": {
       "occurrencesFormSectionTitle": "Occurrences",
       "labelEventHasNoOccurrences": "This event doesn't have specific occurrence time",
-      "buttonAddNewOccurence": "Add new occurrence"
+      "buttonAddNewOccurence": "Add new occurrence",
+      "saveSuccesful": "Occurrence saved"
     }
   },
   "events": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -431,7 +431,8 @@
     "occurrences": {
       "occurrencesFormSectionTitle": "Tapahtuma-aika",
       "labelEventHasNoOccurrences": "Tapahtumalla ei ole lukittua ajankohtaa",
-      "buttonAddNewOccurence": "Lisää uusi tapahtuma-aika"
+      "buttonAddNewOccurence": "Lisää uusi tapahtuma-aika",
+      "saveSuccesful": "Tapahtuma-aika tallennettu"
     }
   },
   "events": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -432,7 +432,8 @@
     "occurrences": {
       "occurrencesFormSectionTitle": "Evenemangets tidpunkt",
       "labelEventHasNoOccurrences": "Den här händelsen har ingen specifik förekomsttid",
-      "buttonAddNewOccurence": "Läg till ny tidpunkt"
+      "buttonAddNewOccurence": "Läg till ny tidpunkt",
+      "saveSuccesful": "Tidpunkt har sparats"
     }
   },
   "events": {

--- a/src/domain/event/CreateEventPage.tsx
+++ b/src/domain/event/CreateEventPage.tsx
@@ -39,12 +39,14 @@ const CreateEventPage: React.FC = () => {
   const apolloClient = useApolloClient();
   const { t } = useTranslation();
   const history = useHistory();
-  const updateImageRequestHandler = useUpdateImageRequest();
+  const [updateImageRequestHandler, updateImageLoading] =
+    useUpdateImageRequest();
   const [loading, setLoading] = useState(true);
   const [initialValues, setInitialValues] = useState<CreateEventFormFields>(
     createEventInitialValues
   );
-  const [createEvent] = useCreateEventMutation();
+  const [createEvent, { loading: createEventLoading }] =
+    useCreateEventMutation();
 
   const selectedOrganisation = useSelectedOrganisation();
 
@@ -161,6 +163,7 @@ const CreateEventPage: React.FC = () => {
               formType={eventIdToCopy ? 'template' : 'new'}
               onCancel={goToEventList}
               onSubmit={handleSubmit}
+              eventMutationLoading={createEventLoading || updateImageLoading}
               persons={persons}
               initialValues={initialValues}
               title={t('createEvent.title')}

--- a/src/domain/event/EditEventPage.tsx
+++ b/src/domain/event/EditEventPage.tsx
@@ -51,8 +51,9 @@ const useEventFormEditSubmit = (
   const { t } = useTranslation();
   const history = useHistory();
   const locale = useLocale();
-  const [editEvent] = useEditEventMutation();
-  const updateImageRequestHandler = useUpdateImageRequest();
+  const [editEvent, { loading: editEventLoading }] = useEditEventMutation();
+  const [updateImageRequestHandler, updateImageLoading] =
+    useUpdateImageRequest();
   const navigatedFrom = useSearchParams().get(
     EDIT_EVENT_QUERY_PARAMS.NAVIGATED_FROM
   );
@@ -148,16 +149,17 @@ const useEventFormEditSubmit = (
     }
   };
 
-  return submit;
+  const isLoading = editEventLoading || updateImageLoading;
+
+  return [submit, isLoading] as const;
 };
 
 const EditEventPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { t } = useTranslation();
   const history = useHistory();
-  const [initialValues, setInitialValues] = useState<CreateEventFormFields>(
-    eventInitialValues
-  );
+  const [initialValues, setInitialValues] =
+    useState<CreateEventFormFields>(eventInitialValues);
 
   const { data: eventData, loading } = useEventQuery({
     fetchPolicy: 'network-only',
@@ -180,7 +182,10 @@ const EditEventPage: React.FC = () => {
     }
   }, [eventData]);
 
-  const onSubmit = useEventFormEditSubmit(initialValues, eventData);
+  const [onSubmit, editEventLoading] = useEventFormEditSubmit(
+    initialValues,
+    eventData
+  );
 
   return (
     <PageWrapper title="editEvent.pageTitle">
@@ -199,6 +204,7 @@ const EditEventPage: React.FC = () => {
                   onCancel={goToEventDetailsPage}
                   onSubmit={onSubmit}
                   persons={persons}
+                  eventMutationLoading={editEventLoading}
                   title={t('editEvent.title')}
                 />
               </div>

--- a/src/domain/event/EventSummaryPage.tsx
+++ b/src/domain/event/EventSummaryPage.tsx
@@ -43,12 +43,17 @@ const EventSummaryPage: React.FC = () => {
   const locale = useLocale();
   const lang = i18n.language;
   const [showAllPastEvents, setShowAllPastEvents] = React.useState(false);
-  const { data: eventData, loading, refetch: refetchEventData } = useEventQuery(
-    {
-      // fetchPolicy: 'network-only',
-      variables: { id: eventId, include: ['location', 'keywords'] },
-    }
-  );
+  const {
+    data: eventData,
+    loading,
+    refetch: refetchEventData,
+  } = useEventQuery({
+    // fetchPolicy: 'network-only',
+    variables: {
+      id: eventId,
+      include: ['location', 'keywords', 'in_language'],
+    },
+  });
 
   const downloadEnrolmentsQuery = useDownloadEventsEnrolmentsCsvQuery(
     eventData?.event?.pEvent?.id

--- a/src/domain/event/__tests__/EventSummaryPage.test.tsx
+++ b/src/domain/event/__tests__/EventSummaryPage.test.tsx
@@ -33,6 +33,8 @@ import { ROUTES } from '../../app/routes/constants';
 import { PUBLICATION_STATUS } from '../../events/constants';
 import EventSummaryPage from '../EventSummaryPage';
 
+const includeArray = ['location', 'keywords', 'in_language'];
+
 configure({ defaultHidden: true });
 
 const eventId1 = 'eventMockId';
@@ -133,7 +135,7 @@ const eventResponseWithOneCancelledOccurrence = {
     query: EventDocument,
     variables: {
       id: eventId1,
-      include: ['location', 'keywords'],
+      include: includeArray,
     },
   },
   result: {
@@ -159,7 +161,7 @@ const getMocks = ({
       query: EventDocument,
       variables: {
         id: eventId1,
-        include: ['location', 'keywords'],
+        include: includeArray,
       },
     },
     result: {
@@ -173,7 +175,7 @@ const getMocks = ({
       query: EventDocument,
       variables: {
         id: eventId2,
-        include: ['location', 'keywords'],
+        include: includeArray,
       },
     },
     result: {

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -68,6 +68,7 @@ type Props<T extends FormFields> = {
   title: string;
   edit?: boolean;
   formType?: FormType;
+  eventMutationLoading: boolean;
 };
 
 const EventForm = <T extends FormFields>({
@@ -78,6 +79,7 @@ const EventForm = <T extends FormFields>({
   title,
   formType = 'new',
   eventData,
+  eventMutationLoading,
 }: Props<T>): React.ReactElement => {
   const isPrefilledForm = formType === 'edit' || formType === 'template';
   const history = useHistory();
@@ -409,7 +411,7 @@ const EventForm = <T extends FormFields>({
                     >
                       {t('eventForm.buttonCancel')}
                     </Button>
-                    <Button type="submit">
+                    <Button type="submit" disabled={eventMutationLoading}>
                       {formType === 'edit'
                         ? t('eventForm.buttonUpdate')
                         : t('eventForm.buttonSaveAndGoToOccurrences')}

--- a/src/domain/event/eventForm/useEventFormSubmitRequests.tsx
+++ b/src/domain/event/eventForm/useEventFormSubmitRequests.tsx
@@ -24,9 +24,10 @@ const useCreateOrUpdateVenueRequest = (apolloClient: ApolloClient<object>) => {
 };
 
 const useUpdateImageRequest = () => {
-  const [updateImage] = useUpdateSingleImageMutation();
+  const [updateImage, { loading: updateImageLoading }] =
+    useUpdateSingleImageMutation();
 
-  return (values: CreateEventFormFields) => {
+  const updateImageRequest = (values: CreateEventFormFields) => {
     const imageId = values.image;
     if (imageId) {
       const imageName = getImageName(imageId);
@@ -45,6 +46,8 @@ const useUpdateImageRequest = () => {
       }
     }
   };
+
+  return [updateImageRequest, updateImageLoading] as const;
 };
 
 export { useCreateOrUpdateVenueRequest, useUpdateImageRequest };

--- a/src/domain/occurrence/CreateOccurrencePage.tsx
+++ b/src/domain/occurrence/CreateOccurrencePage.tsx
@@ -420,15 +420,16 @@ const OccurrenceInfoForm: React.FC<{
           // Handle submitting both event info and occurrence form
           const handleGoToPublishingClick: React.MouseEventHandler<HTMLButtonElement> =
             async (e) => {
-              await submitOccurrenceFormIfNeeded();
               try {
                 const hasBeenSubmitted = isValid && !dirty;
                 if (!hasBeenSubmitted) {
                   await submitForm();
                 }
+                await submitOccurrenceFormIfNeeded();
                 if (isValid) {
                   onGoToPublishingClick(e);
                 }
+                // async funcs in try block already handle errors
               } catch {}
             };
 
@@ -436,8 +437,11 @@ const OccurrenceInfoForm: React.FC<{
           const handleSaveClick: React.MouseEventHandler<HTMLButtonElement> =
             async (e) => {
               e.preventDefault();
-              await submitOccurrenceFormIfNeeded();
-              await submitForm();
+              try {
+                await submitForm();
+                await submitOccurrenceFormIfNeeded();
+                // async funcs in try block already handle errors
+              } catch {}
             };
 
           return (

--- a/src/domain/occurrence/OccurrencesFormHandleContext.tsx
+++ b/src/domain/occurrence/OccurrencesFormHandleContext.tsx
@@ -1,0 +1,34 @@
+import { FormikContextType, useFormikContext } from 'formik';
+import * as React from 'react';
+
+import { OccurrenceSectionFormFields } from './types';
+
+/*
+ * This react context is used to get access to formik functions for a form
+ * from higher in the react tree
+ *
+ * Empty ref object is passed to the provider and child can assign formik
+ * props to that ref
+ */
+export const OccurrencesFormHandleContext = React.createContext<
+  React.MutableRefObject<{} | FormikContextType<OccurrenceSectionFormFields>>
+>({ current: {} });
+
+export const useOccurrenceForm = () => {
+  const context = React.useContext(OccurrencesFormHandleContext);
+
+  if (context === undefined) {
+    throw new Error(
+      'useOccurrenceForm must be used within a OccurrencesFormHandleProvider'
+    );
+  }
+
+  return context;
+};
+
+export const OccurrenceFormContextSetter = () => {
+  const formikContext = useFormikContext<OccurrenceSectionFormFields>();
+  const context = useOccurrenceForm();
+  context.current = formikContext;
+  return null;
+};

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -94,7 +94,6 @@ describe('location and enrolment info', () => {
     renderComponent({
       mocks: [
         eventWithoutEnrolmentAndLocationInfoMockedResponse,
-        eventWithoutEnrolmentAndLocationInfoMockedResponse,
         updateEventMockResponse,
       ],
     });
@@ -202,7 +201,6 @@ describe('location and enrolment info', () => {
     renderComponent({
       mocks: [
         eventWithEnrolmentAndLocationInfoMockedResponse,
-        eventWithEnrolmentAndLocationInfoMockedResponse,
         updateEventMockResponse,
       ],
     });
@@ -289,7 +287,6 @@ describe('location and enrolment info', () => {
       });
     renderComponent({
       mocks: [
-        eventWithMultipleLanguagesMockedResponse,
         eventWithMultipleLanguagesMockedResponse,
         updateEventWithMultipleLanguagesMockResponse,
       ],
@@ -769,6 +766,128 @@ describe('occurrences form', () => {
   });
 });
 
+describe('save occurrence and event info simultaneously', () => {
+  it('saves occurrence and event info when using save button', async () => {
+    advanceTo('2021-04-02');
+    const enrolmentStartDateTimeValue = '2021-05-03T21:00:00.000Z';
+    const occurrenceStartTime = '10.05.2021 10:00';
+    const occurrenceEndTime = '10.05.2021 11:00';
+    const occurrenceData1 = {
+      amountOfSeats: 30,
+      seatType: graphql.OccurrenceSeatType.ChildrenCount,
+      languages: ['fi', 'en'],
+      minGroupSize: 10,
+      maxGroupSize: 20,
+      endTime: occurrenceEndTime,
+      startTime: occurrenceStartTime,
+    };
+    const formattedEnrolmentStartTime = format(
+      new Date(enrolmentStartDateTimeValue),
+      'dd.MM.yyyy HH:mm'
+    );
+    const eventWithoutEnrolmentAndLocationInfoMockedResponse =
+      getEventMockedResponse({
+        location: false,
+        autoAcceptance: true,
+        enrolmentEndDays: null,
+        enrolmentStart: null,
+        neededOccurrences: 1,
+        occurrences: fakeOccurrences(0),
+      });
+    const updateEventMockResponse = getUpdateEventMockResponse({
+      autoAcceptance: true,
+      enrolmentEndDays: 1,
+      enrolmentStart: enrolmentStartDateTimeValue,
+      neededOccurrences: 1,
+    });
+    const addOccurrenceMockResponse =
+      getAddOccurrenceMockResponse(occurrenceData1);
+    const occurrence1: Partial<OccurrenceNode> = {
+      ...occurrenceData1,
+      languages: fakeLanguages([{ id: 'en' }, { id: 'fi' }]),
+      startTime: parseDate(occurrenceStartTime, 'dd.MM.yyyy HH:mm', new Date()),
+      endTime: parseDate(occurrenceEndTime, 'dd.MM.yyyy HH:mm', new Date()),
+      placeId: placeId,
+    };
+
+    renderComponent({
+      mocks: [
+        eventWithoutEnrolmentAndLocationInfoMockedResponse,
+        updateEventMockResponse,
+        getEventMockedResponse({
+          occurrences: fakeOccurrences(1, [occurrence1]),
+        }),
+        addOccurrenceMockResponse,
+      ],
+    });
+
+    const toastSuccess = jest.spyOn(toast, 'success');
+    // Wait for form to have been initialized
+    await screen.findByTestId('time-and-location-form');
+
+    const locationInput = getFormElement('location');
+    expect(locationInput.parentElement).toHaveTextContent('');
+
+    act(() => userEvent.click(locationInput));
+    userEvent.type(locationInput, 'Sellon');
+
+    const place = await screen.findByText(/Sellon kirjasto/i);
+    act(() => userEvent.click(place));
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('Tapahtumapaikan kuvaus (FI)')
+      ).toHaveTextContent(venueDescription);
+    });
+
+    // Text is contained in a div that is sibling to the input
+    expect(locationInput.parentElement).toHaveTextContent('Sellon kirjasto');
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: /ulkovaatesäilytys/i,
+      })
+    ).toBeChecked();
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: /leikkitilaa ulkona/i,
+      })
+    ).not.toBeChecked();
+
+    const enrolmentStartDateTimeInput = getFormElement('enrolmentStart');
+    const enrolmentEndDaysInput = getFormElement('enrolmentEndDays');
+
+    act(() => userEvent.click(enrolmentStartDateTimeInput));
+    userEvent.type(enrolmentStartDateTimeInput, formattedEnrolmentStartTime);
+    fireEvent.blur(enrolmentStartDateTimeInput);
+    userEvent.type(enrolmentEndDaysInput, '1');
+
+    await waitFor(() => {
+      expect(enrolmentStartDateTimeInput).toHaveValue(
+        formattedEnrolmentStartTime
+      );
+    });
+
+    await fillAndSubmitOccurrenceForm({
+      occurrenceStartTime,
+      occurrenceEndTime,
+      submit: false,
+    });
+
+    userEvent.click(getFormElement('saveButton'));
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledTimes(2);
+    });
+
+    expect(toastSuccess).toHaveBeenCalledWith('Tapahtuma-aika tallennettu');
+    expect(toastSuccess).toHaveBeenCalledWith('Tiedot tallennettu');
+  });
+
+  it.todo('saves occurrence and event info when using to go to publish button');
+});
+
 describe('venue info', () => {
   test('venue data can be changed and saved', async () => {
     advanceTo('2021-04-02');
@@ -974,9 +1093,11 @@ const getFormElement = (
 const fillAndSubmitOccurrenceForm = async ({
   occurrenceEndTime,
   occurrenceStartTime,
+  submit = true,
 }: {
   occurrenceStartTime: string;
   occurrenceEndTime: string;
+  submit?: boolean;
 }) => {
   const withinOccurrencesForm = within(
     screen.getByTestId(occurrencesFormTestId)
@@ -1050,22 +1171,24 @@ const fillAndSubmitOccurrenceForm = async ({
   expect(minGroupSizeInput).toHaveValue(10);
   expect(maxGroupSizeInput).toHaveValue(20);
 
-  const submitButton = getOccurrenceFormElement('submit');
-  userEvent.click(submitButton);
+  if (submit) {
+    const submitButton = getOccurrenceFormElement('submit');
+    userEvent.click(submitButton);
 
-  const goToPublishingButton = getFormElement('goToPublishing');
-  const saveEventDataButton = getFormElement('saveButton');
-  const addNewOccurrenceButton = getOccurrenceFormElement('submit');
+    const goToPublishingButton = getFormElement('goToPublishing');
+    const saveEventDataButton = getFormElement('saveButton');
+    const addNewOccurrenceButton = getOccurrenceFormElement('submit');
 
-  // All buttons should be disabled when loading
-  await waitFor(() => {
-    expect(goToPublishingButton).toBeDisabled();
-    expect(addNewOccurrenceButton).toBeDisabled();
-    expect(saveEventDataButton).toBeDisabled();
-  });
+    // All buttons should be disabled when loading
+    await waitFor(() => {
+      expect(goToPublishingButton).toBeDisabled();
+      expect(addNewOccurrenceButton).toBeDisabled();
+      expect(saveEventDataButton).toBeDisabled();
+    });
 
-  await waitFor(() => {
-    expect(occurrenceStartsAtInput).toHaveValue('');
-    expect(occurrenceEndsAtInput).toHaveValue('');
-  });
+    await waitFor(() => {
+      expect(occurrenceStartsAtInput).toHaveValue('');
+      expect(occurrenceEndsAtInput).toHaveValue('');
+    });
+  }
 };

--- a/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
+++ b/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
@@ -125,6 +125,7 @@ const OccurrencesForm: React.FC<{
           });
         },
       });
+      toast.success(t('eventForm.occurrences.saveSuccesful'));
     } catch (e) {
       // Put form values back if mutation happens to fail.
       action.setValues(values);

--- a/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
+++ b/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
@@ -133,6 +133,7 @@ const OccurrencesForm: React.FC<{
       toast(t('createOccurrence.error'), {
         type: toast.TYPE.ERROR,
       });
+      return Promise.reject(e);
     }
   };
 

--- a/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
+++ b/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
@@ -20,12 +20,17 @@ import {
 } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import { getEventFields } from '../../event/utils';
+import { OccurrenceFormContextSetter } from '../../occurrence/OccurrencesFormHandleContext';
 import PlaceText from '../../place/PlaceText';
 import {
   OccurrenceSectionFormFields,
   TimeAndLocationFormFields,
 } from '../types';
-import { getOccurrenceFields, getOccurrencePayload } from '../utils';
+import {
+  getEventQueryVariables,
+  getOccurrenceFields,
+  getOccurrencePayload,
+} from '../utils';
 import styles from './occurrencesFormPart.module.scss';
 import {
   addOccurrencesToCache,
@@ -76,11 +81,7 @@ const OccurrencesForm: React.FC<{
     () => getValidationSchema({ isVirtual, enrolmentEndDays, enrolmentStart }),
     [enrolmentEndDays, enrolmentStart, isVirtual]
   );
-
-  const eventVariables = {
-    id: eventId ?? '',
-    include: ['location', 'keywords', 'audience'],
-  };
+  const eventVariables = getEventQueryVariables(eventId ?? '');
 
   const reinitializeForm = (
     values: OccurrenceSectionFormFields,
@@ -239,6 +240,7 @@ const OccurrenceForm: React.FC<{
   return (
     <div className={styles.eventOccurrenceForm}>
       <div className={styles.occurrenceFormRow}>
+        <OccurrenceFormContextSetter />
         <Field
           labelText={t('eventOccurrenceForm.labelEventLocation')}
           name="occurrenceLocation"

--- a/src/domain/occurrence/utils.ts
+++ b/src/domain/occurrence/utils.ts
@@ -43,16 +43,18 @@ export const getOccurrencePayload = ({
   };
 };
 
+export const getEventQueryVariables = (id: string) => ({
+  id,
+  include: ['location', 'keywords', 'audience', 'in_language'],
+});
+
 // Reused query, helps with refetching
 export const useBaseEventQuery: typeof useEventQuery = ({
   variables,
   ...options
 } = {}) => {
   return useEventQuery({
-    variables: {
-      id: variables?.id ?? '',
-      include: ['location', 'keywords', 'audience'],
-    },
+    variables: getEventQueryVariables(variables?.id ?? ''),
     ...options,
   });
 };

--- a/src/test/CreateOccurrencePageTestUtils.ts
+++ b/src/test/CreateOccurrencePageTestUtils.ts
@@ -419,7 +419,7 @@ export const getEventMockedResponse = ({
     query: EventDocument,
     variables: {
       id: eventId,
-      include: ['location', 'keywords', 'audience'],
+      include: ['location', 'keywords', 'audience', 'in_language'],
     },
   },
   result: getEventResponse({

--- a/src/test/CreateOccurrencePageTestUtils.ts
+++ b/src/test/CreateOccurrencePageTestUtils.ts
@@ -409,8 +409,8 @@ export const getEventMockedResponse = ({
 }: {
   location?: boolean;
   autoAcceptance?: boolean;
-  enrolmentEndDays?: number;
-  enrolmentStart?: string;
+  enrolmentEndDays?: number | null;
+  enrolmentStart?: string | null;
   neededOccurrences?: number;
   languages?: Languages[];
   occurrences?: OccurrenceNodeConnection;


### PR DESCRIPTION
## Description :sparkles:

- Submit also occurrence form when using save button for enrolment info form
- Also submit occurrence form when navigating to publish page if occurrence form is valid and filled

- Disable submit button on main event form when clicked and requests are pending

## Issues :bug:
### Closes :no_good_woman:
**[PT-1047](https://helsinkisolutionoffice.atlassian.net/browse/PT-1047):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: