### PR TITLE
fix: hard coded a Finnish registration pending text instead of lorem ipsum.

### DIFF
--- a/src/domain/app/register/RegistrationPendingPage.module.scss
+++ b/src/domain/app/register/RegistrationPendingPage.module.scss
@@ -25,4 +25,7 @@
     box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.2);
     padding: var(--spacing-xl);
   }
+  address {
+    margin-top: 10px;
+  }
 }

--- a/src/domain/app/register/RegistrationPendingPage.tsx
+++ b/src/domain/app/register/RegistrationPendingPage.tsx
@@ -21,14 +21,20 @@ const RegistrationPendingPage: React.FC = () => {
           <div>
             <h2>{t('registrationPendingPage.title2')}</h2>
             <p>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-              enim ad minim veniam, quis nostrud exercitation ullamco laboris
-              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-              reprehenderit in voluptate velit esse cillum dolore eu fugiat
-              nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-              sunt in culpa qui officia deserunt mollit anim id est laborum.
+              Käsittelemme rekisteröitymisesi viimeistään seuraavana
+              arkipäivänä. Saat sähköpostiisi ilmoituksen, kun käyttäjätilisi on
+              aktivoitu.
             </p>
+            <h3>Lisätietoja</h3>
+            <address>
+              Katri Aikio
+              <br />
+              katri.aikio@hel.fi
+              <br />
+              0404866869
+              <br />
+              Kultus beta
+            </address>
           </div>
         </div>
       </Container>


### PR DESCRIPTION
In future, instead of using a hard coded (Finnish only) text and a contact information address-block, the content should be fetched from to-be-done headless CMS.

PT-1113. 