### PR TITLE
fix(editor): strip pasted styles in event description editor

### DIFF
--- a/src/common/components/textEditor/TextEditor.tsx
+++ b/src/common/components/textEditor/TextEditor.tsx
@@ -129,6 +129,7 @@ const TextEditor: React.FC<TextEditorProps> = ({
             handleChange(value);
             setFocused(false);
           }}
+          stripPastedStyles
           onFocus={() => setFocused(true)}
           editorClassName={classNames(styles.editor, {
             [styles.focused]: focused,

--- a/src/domain/event/__tests__/CreateEventPage.test.tsx
+++ b/src/domain/event/__tests__/CreateEventPage.test.tsx
@@ -87,7 +87,7 @@ const imageAltText = 'AltText';
 const defaultFormData = {
   name: createFinnishLocalisedObject(eventName, true),
   shortDescription: createFinnishLocalisedObject(shortDescription, true),
-  description: createFinnishLocalisedObject(descriptionEditorHTML, true),
+  description: createFinnishLocalisedObject(description, true),
   infoUrl: createFinnishLocalisedObject(infoUrl, true),
   contactEmail: 'testi@testi.fi',
   contactPhoneNumber: '123123123',
@@ -111,7 +111,7 @@ const createEventVariables = {
       },
     ],
     shortDescription: defaultFormData.shortDescription,
-    description: defaultFormData.description,
+    description: createFinnishLocalisedObject(descriptionEditorHTML, true),
     images: [{ internalId: '/image/48584/' }],
     infoUrl: defaultFormData.infoUrl,
     audience: audienceKeywords.map((k) => ({ internalId: getKeywordId(k.id) })),


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:
**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: