### PR TITLE
PT-1131 | fix pagination when server returns error

### DIFF
--- a/src/domain/app/apollo/apolloClient.ts
+++ b/src/domain/app/apollo/apolloClient.ts
@@ -61,7 +61,7 @@ export const createApolloCache = () =>
             // Docs: https://www.apollographql.com/docs/react/pagination/key-args/
             keyArgs: excludeArgs(['page']),
             merge(existing, incoming) {
-              if (!incoming) return null;
+              if (!incoming) return existing;
               return {
                 data: [...(existing?.data ?? []), ...incoming.data],
                 meta: incoming.meta,

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -454,7 +454,7 @@
     "titleComingEvents": "Events",
     "titleEventsWithPastOccurrences": "Past events",
     "titleEventsWithoutOccurrences": "Events without event times",
-    "errorFetchMoreEvents": "Fetching more events failed"
+    "errorFetchMoreEvents": "Failed to load more events"
   },
   "eventSummary": {
     "buttonBack": "Back to occurrences",

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -453,7 +453,8 @@
     "title": "Events",
     "titleComingEvents": "Events",
     "titleEventsWithPastOccurrences": "Past events",
-    "titleEventsWithoutOccurrences": "Events without event times"
+    "titleEventsWithoutOccurrences": "Events without event times",
+    "errorFetchMoreEvents": "Fetching more events failed"
   },
   "eventSummary": {
     "buttonBack": "Back to occurrences",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -459,7 +459,8 @@
     "title": "Tapahtumat",
     "titleComingEvents": "Tapahtumat",
     "titleEventsWithPastOccurrences": "Menneet tapahtumat",
-    "titleEventsWithoutOccurrences": "Tapahtumat, joilla ei ole tapahtuma-aikoja"
+    "titleEventsWithoutOccurrences": "Tapahtumat, joilla ei ole tapahtuma-aikoja",
+    "errorFetchMoreEvents": "Virhe ladattaessa lisää tapahtumia"
   },
   "eventSummary": {
     "buttonBack": "Takaisin tapahtuma-aikoihin",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -460,7 +460,7 @@
     "titleComingEvents": "Tapahtumat",
     "titleEventsWithPastOccurrences": "Menneet tapahtumat",
     "titleEventsWithoutOccurrences": "Tapahtumat, joilla ei ole tapahtuma-aikoja",
-    "errorFetchMoreEvents": "Virhe ladattaessa lisää tapahtumia"
+    "errorFetchMoreEvents": "Tapahtumien lataaminen epäonnistui"
   },
   "eventSummary": {
     "buttonBack": "Takaisin tapahtuma-aikoihin",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -460,7 +460,8 @@
     "title": "Evenemang",
     "titleComingEvents": "Evenemang",
     "titleEventsWithPastOccurrences": "Tidigare evenemang",
-    "titleEventsWithoutOccurrences": "Evenemang utan evenemangtider"
+    "titleEventsWithoutOccurrences": "Evenemang utan evenemangtider",
+    "errorFetchMoreEvents": "Det gick inte att hämta fler händelser"
   },
   "eventSummary": {
     "buttonBack": "Tillbaka till evenemangstiderna",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -461,7 +461,7 @@
     "titleComingEvents": "Evenemang",
     "titleEventsWithPastOccurrences": "Tidigare evenemang",
     "titleEventsWithoutOccurrences": "Evenemang utan evenemangtider",
-    "errorFetchMoreEvents": "Det gick inte att hämta fler händelser"
+    "errorFetchMoreEvents": "Det gick inte att ladda evenemangen"
   },
   "eventSummary": {
     "buttonBack": "Tillbaka till evenemangstiderna",

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -1,5 +1,7 @@
 import { QueryHookOptions } from '@apollo/client';
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
 
 import {
   EventsQuery,
@@ -12,6 +14,7 @@ export const useEventsQueryHelper = ({
   variables,
 }: QueryHookOptions<EventsQuery, EventsQueryVariables>) => {
   const [isLoadingMore, setIsLoadingMore] = React.useState(false);
+  const { t } = useTranslation();
 
   const {
     fetchMore: fetchMoreEvents,
@@ -40,6 +43,9 @@ export const useEventsQueryHelper = ({
         });
         setIsLoadingMore(false);
       } catch (e) {
+        toast(t('events.errorFetchMoreEvents'), {
+          type: toast.TYPE.ERROR,
+        });
         setIsLoadingMore(false);
       }
     }


### PR DESCRIPTION
## Description :sparkles:

- Fix bug where event list would disappear after pagination query return error from server

## Issues :bug:
### Closes :no_good_woman:
**[PT-1131](https://helsinkisolutionoffice.atlassian.net/browse/PT-1131):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: