### PR TITLE
fix(occurrence): removed the unpublish event button

### DIFF
--- a/src/domain/event/__tests__/EventSummaryPage.test.tsx
+++ b/src/domain/event/__tests__/EventSummaryPage.test.tsx
@@ -361,12 +361,6 @@ it('hides edit buttons when event has been published', async () => {
       name: 'Muokkaa perustietoja',
     })
   ).toBeInTheDocument();
-
-  expect(
-    screen.queryByRole('button', {
-      name: 'Peru julkaisu',
-    })
-  ).toBeInTheDocument();
 });
 
 it('shows upcoming and past occurrences', async () => {

--- a/src/domain/event/eventPublish/EventPublish.tsx
+++ b/src/domain/event/eventPublish/EventPublish.tsx
@@ -77,12 +77,13 @@ const EventPublish: React.FC<Props> = ({ event }) => {
               {t('occurrences.publishSection.textPublishedTime')}{' '}
               {getEventPublishedTime(event)}
             </div>
-            <Button
+            {/*TODO: Implement unpublish*/}
+            {/* <Button
               className={styles.publishButton}
               onClick={() => alert('TODO: implement unpublish')}
             >
               {t('occurrences.publishSection.buttonCancelPublishment')}
-            </Button>
+            </Button> */}
           </>
         ) : (
           <>


### PR DESCRIPTION
The unpublish event button has never been in use and it was an unimplemented feature in UI, so the button is now removed, so it would not haunt the users. 

NOTE: Unpublish feature is already implemented in the API. It was only missing from UI, but it was not clear whether it is really wanted or not, because it could make a hazzle.

PT-1148.