### PR TITLE
feat(enrolment-type): events enrolment info differs on different enrolment type

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -448,6 +448,8 @@
       "ariaLabelOpenOccurrences": "Go to event times of {{eventName}}",
       "textEnrolments": "{{count}} enrolments",
       "textEnrolments_plural": "{{count}} enrolments",
+      "textExternalEnrolments": "Enrolments on another site",
+      "textUnenrollable": "No enrolments",
       "textOccurrences": "{{count}} occurrence",
       "textOccurrences_plural": "{{count}} occurrences",
       "statusPublished": "Published",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -454,6 +454,8 @@
       "ariaLabelOpenOccurrences": "Siirry tapahtuman {{eventName}} tapahtuma-aikoihin",
       "textEnrolments": "{{count}} ilmoittautunut",
       "textEnrolments_plural": "{{count}} ilmoittautunutta",
+      "textExternalEnrolments": "Ilmoittautuminen muulla sivustolla",
+      "textUnenrollable": "Ei ilmoittautumista",
       "textOccurrences": "{{count}} tapahtuma-aika",
       "textOccurrences_plural": "{{count}} tapahtuma-aikaa",
       "statusPublished": "Julkaistu",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -455,6 +455,8 @@
       "ariaLabelOpenOccurrences": "Gå till evenemangtided av {{eventName}}",
       "textEnrolments": "{{count}} registrerad",
       "textEnrolments_plural": "{{count}} registrerade",
+      "textExternalEnrolments": "Anmälningar på en annan webbplats",
+      "textUnenrollable": "Inga anmälningar",
       "textOccurrences": "{{count}} händelsetid",
       "textOccurrences_plural": "{{count}} evenemangtider",
       "statusPublished": "Publicerad",

--- a/src/domain/event/EventSummaryPage.tsx
+++ b/src/domain/event/EventSummaryPage.tsx
@@ -50,7 +50,6 @@ const EventSummaryPage: React.FC = () => {
     loading,
     refetch: refetchEventData,
   } = useEventQuery({
-    // fetchPolicy: 'network-only',
     variables: {
       id: eventId,
       include: ['location', 'keywords', 'in_language'],
@@ -62,9 +61,11 @@ const EventSummaryPage: React.FC = () => {
   );
   const [cancelOccurrence] = useCancelOccurrenceMutation();
 
+  const enrolmentType = eventData?.event && getEnrolmentType(eventData.event);
   const organisationId = eventData?.event?.pEvent?.organisation?.id || '';
   const isEventDraft =
     eventData?.event?.publicationStatus === PUBLICATION_STATUS.DRAFT;
+  const isInternalEnrolment = enrolmentType === EnrolmentType.Internal;
 
   const occurrences =
     (eventData?.event?.pEvent?.occurrences.edges.map(
@@ -131,8 +132,6 @@ const EventSummaryPage: React.FC = () => {
     }
   };
 
-  const enrolmentType = eventData?.event && getEnrolmentType(eventData.event);
-
   return (
     <PageWrapper title="occurrences.pageTitle">
       <LoadingSpinner isLoading={loading}>
@@ -193,7 +192,7 @@ const EventSummaryPage: React.FC = () => {
                       })}
                     </span>
                   </h2>
-                  {!isEventDraft && enrolmentType === EnrolmentType.Internal && (
+                  {!isEventDraft && isInternalEnrolment && (
                     <Button onClick={downloadEnrolments} variant="secondary">
                       {t('eventSummary.buttonExportEnrolments')}
                     </Button>

--- a/src/domain/event/EventSummaryPage.tsx
+++ b/src/domain/event/EventSummaryPage.tsx
@@ -25,6 +25,8 @@ import { ROUTES } from '../app/routes/constants';
 import ErrorPage from '../errorPage/ErrorPage';
 import EventPreviewCard from '../event/eventPreviewCard/EventPreviewCard';
 import { PUBLICATION_STATUS } from '../events/constants';
+import { EnrolmentType } from '../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { getEnrolmentType } from '../occurrence/utils';
 import OccurrencesTableSummary from '../occurrences/occurrencesTableReadOnly/OccurrencesTableSummary';
 import ActiveOrganisationInfo from '../organisation/activeOrganisationInfo/ActiveOrganisationInfo';
 import { EDIT_EVENT_QUERY_PARAMS, NAVIGATED_FROM } from './EditEventPage';
@@ -129,6 +131,8 @@ const EventSummaryPage: React.FC = () => {
     }
   };
 
+  const enrolmentType = eventData?.event && getEnrolmentType(eventData.event);
+
   return (
     <PageWrapper title="occurrences.pageTitle">
       <LoadingSpinner isLoading={loading}>
@@ -189,7 +193,7 @@ const EventSummaryPage: React.FC = () => {
                       })}
                     </span>
                   </h2>
-                  {!isEventDraft && (
+                  {!isEventDraft && enrolmentType === EnrolmentType.Internal && (
                     <Button onClick={downloadEnrolments} variant="secondary">
                       {t('eventSummary.buttonExportEnrolments')}
                     </Button>

--- a/src/domain/event/EventSummaryPage.tsx
+++ b/src/domain/event/EventSummaryPage.tsx
@@ -25,7 +25,7 @@ import { ROUTES } from '../app/routes/constants';
 import ErrorPage from '../errorPage/ErrorPage';
 import EventPreviewCard from '../event/eventPreviewCard/EventPreviewCard';
 import { PUBLICATION_STATUS } from '../events/constants';
-import { EnrolmentType } from '../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from '../occurrence/constants';
 import { getEnrolmentType } from '../occurrence/utils';
 import OccurrencesTableSummary from '../occurrences/occurrencesTableReadOnly/OccurrencesTableSummary';
 import ActiveOrganisationInfo from '../organisation/activeOrganisationInfo/ActiveOrganisationInfo';

--- a/src/domain/event/__tests__/EventSummaryPage.test.tsx
+++ b/src/domain/event/__tests__/EventSummaryPage.test.tsx
@@ -121,6 +121,14 @@ const eventMock2 = getFakeEvent(
   }
 );
 
+const eventMockWithExternalEnrolments = getFakeEvent(
+  {
+    id: eventId1,
+    publicationStatus: PUBLICATION_STATUS.PUBLIC,
+  },
+  { enrolmentStart: null, externalEnrolmentUrl: 'https://beta.kultus.fi' }
+);
+
 const profileMock = fakePerson({
   organisations: fakeOrganisations(1, [
     fakeOrganisation({
@@ -361,6 +369,28 @@ it('hides edit buttons when event has been published', async () => {
       name: 'Muokkaa perustietoja',
     })
   ).toBeInTheDocument();
+
+  expect(
+    screen.getByRole('button', {
+      name: /lataa ilmoittautumiset \(csv\)/i,
+    })
+  ).toBeInTheDocument();
+});
+
+it('does not show enrolments download button when enrolments are not done internally', async () => {
+  renderWithRoute(<EventSummaryPage />, {
+    mocks: getMocks({ event1: eventMockWithExternalEnrolments }),
+    path: ROUTES.EVENT_SUMMARY,
+    routes: [`/events/${eventId1}/summary`],
+  });
+  await waitFor(() => {
+    expect(screen.queryByText(organisationName)).toBeInTheDocument();
+  });
+  expect(
+    screen.queryByRole('button', {
+      name: /lataa ilmoittautumiset \(csv\)/i,
+    })
+  ).not.toBeInTheDocument();
 });
 
 it('shows upcoming and past occurrences', async () => {

--- a/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
+++ b/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
@@ -9,6 +9,8 @@ import formatDate from '../../../utils/formatDate';
 import getLocalizedString from '../../../utils/getLocalizedString';
 import getTimeFormat from '../../../utils/getTimeFormat';
 import ImageInfo from '../../image/imageInfo/ImageInfo';
+import { EnrolmentType } from '../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { getEnrolmentType } from '../../occurrence/utils';
 import styles from './eventBasicInfo.module.scss';
 
 type Props = {
@@ -35,6 +37,9 @@ const EventBasicInfo: React.FC<Props> = ({ eventData, language }) => {
   const imageId = eventData.event?.images[0]?.id;
 
   const infoUrl = getLocalizedString(eventData.event?.infoUrl || {}, language);
+
+  const enrolmentType = eventData.event && getEnrolmentType(eventData.event);
+
   const enrolmentStart = eventData.event?.pEvent?.enrolmentStart
     ? t('eventDetails.basicInfo.enrolmentStart', {
         date: formatDate(new Date(eventData.event?.pEvent?.enrolmentStart)),
@@ -100,20 +105,22 @@ const EventBasicInfo: React.FC<Props> = ({ eventData, language }) => {
         </>
       )}
 
-      <div className={styles.durationRow}>
-        <div>
-          <TextTitle>
-            {t('eventDetails.basicInfo.labelEnrolmentStart')}
-          </TextTitle>
-          <p>{enrolmentStart}</p>
+      {EnrolmentType.Internal === enrolmentType && (
+        <div className={styles.durationRow}>
+          <div>
+            <TextTitle>
+              {t('eventDetails.basicInfo.labelEnrolmentStart')}
+            </TextTitle>
+            <p>{enrolmentStart}</p>
+          </div>
+          <div>
+            <TextTitle>
+              {t('eventDetails.basicInfo.labelEnrolmentEndDays')}
+            </TextTitle>
+            <p>{eventData.event?.pEvent?.enrolmentEndDays}</p>
+          </div>
         </div>
-        <div>
-          <TextTitle>
-            {t('eventDetails.basicInfo.labelEnrolmentEndDays')}
-          </TextTitle>
-          <p>{eventData.event?.pEvent?.enrolmentEndDays}</p>
-        </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
+++ b/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
@@ -39,6 +39,7 @@ const EventBasicInfo: React.FC<Props> = ({ eventData, language }) => {
   const infoUrl = getLocalizedString(eventData.event?.infoUrl || {}, language);
 
   const enrolmentType = eventData.event && getEnrolmentType(eventData.event);
+  const isInternalEnrolment = EnrolmentType.Internal === enrolmentType;
 
   const enrolmentStart = eventData.event?.pEvent?.enrolmentStart
     ? t('eventDetails.basicInfo.enrolmentStart', {
@@ -59,7 +60,6 @@ const EventBasicInfo: React.FC<Props> = ({ eventData, language }) => {
           <p>{name}</p>
         </>
       )}
-
       {shortDescription && (
         <>
           <TextTitle>
@@ -68,7 +68,6 @@ const EventBasicInfo: React.FC<Props> = ({ eventData, language }) => {
           <p>{shortDescription}</p>
         </>
       )}
-
       {description && (
         <>
           <TextTitle>{t('eventDetails.basicInfo.labelDescription')}</TextTitle>
@@ -78,7 +77,6 @@ const EventBasicInfo: React.FC<Props> = ({ eventData, language }) => {
           />
         </>
       )}
-
       <>
         <TextTitle>
           {t('eventDetails.basicInfo.labelMandatoryAdditionalInformation')}
@@ -95,17 +93,14 @@ const EventBasicInfo: React.FC<Props> = ({ eventData, language }) => {
           </p>
         )}
       </>
-
       {imageId && <ImageInfo imageId={imageId} />}
-
       {infoUrl && (
         <>
           <TextTitle>{t('eventDetails.basicInfo.labelInfoUrl')}</TextTitle>
           <p>{infoUrl}</p>
         </>
       )}
-
-      {EnrolmentType.Internal === enrolmentType && (
+      {isInternalEnrolment && (
         <div className={styles.durationRow}>
           <div>
             <TextTitle>

--- a/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
+++ b/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
@@ -9,7 +9,7 @@ import formatDate from '../../../utils/formatDate';
 import getLocalizedString from '../../../utils/getLocalizedString';
 import getTimeFormat from '../../../utils/getTimeFormat';
 import ImageInfo from '../../image/imageInfo/ImageInfo';
-import { EnrolmentType } from '../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from '../../occurrence/constants';
 import { getEnrolmentType } from '../../occurrence/utils';
 import styles from './eventBasicInfo.module.scss';
 

--- a/src/domain/event/eventCard/EventCard.tsx
+++ b/src/domain/event/eventCard/EventCard.tsx
@@ -56,15 +56,13 @@ const EventCard: React.FC<Props> = ({
   };
 
   const getEnrolmentText = () => {
-    if (enrolmentType === EnrolmentType.Internal) {
-      return t('events.eventCard.textEnrolments', {
+    return {
+      [EnrolmentType.Internal]: t('events.eventCard.textEnrolments', {
         count: enrolmentsCount || 0,
-      });
-    } else if (enrolmentType === EnrolmentType.External) {
-      return t('events.eventCard.textExternalEnrolments');
-    } else if (enrolmentType === EnrolmentType.Unenrollable) {
-      return t('events.eventCard.textUnenrollable');
-    }
+      }),
+      [EnrolmentType.External]: t('events.eventCard.textExternalEnrolments'),
+      [EnrolmentType.Unenrollable]: t('events.eventCard.textUnenrollable'),
+    }[enrolmentType];
   };
 
   return (

--- a/src/domain/event/eventCard/EventCard.tsx
+++ b/src/domain/event/eventCard/EventCard.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import IconClock from '../../../icons/IconClock';
 import { PUBLICATION_STATUS } from '../../events/constants';
-import { EnrolmentType } from '../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from '../../occurrence/constants';
 import { getEventPlaceholderImage } from '../utils';
 import styles from './eventCard.module.scss';
 

--- a/src/domain/event/eventCard/EventCard.tsx
+++ b/src/domain/event/eventCard/EventCard.tsx
@@ -4,12 +4,14 @@ import { useTranslation } from 'react-i18next';
 
 import IconClock from '../../../icons/IconClock';
 import { PUBLICATION_STATUS } from '../../events/constants';
+import { EnrolmentType } from '../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
 import { getEventPlaceholderImage } from '../utils';
 import styles from './eventCard.module.scss';
 
 interface Props {
   description?: string;
   enrolmentsCount: number;
+  enrolmentType: EnrolmentType;
   id: string;
   image?: string;
   name: string;
@@ -21,6 +23,7 @@ interface Props {
 const EventCard: React.FC<Props> = ({
   description,
   enrolmentsCount,
+  enrolmentType,
   id,
   image,
   name,
@@ -49,6 +52,18 @@ const EventCard: React.FC<Props> = ({
 
     if (publicationStatus === PUBLICATION_STATUS.DRAFT) {
       return t('events.eventCard.statusNotPublished');
+    }
+  };
+
+  const getEnrolmentText = () => {
+    if (enrolmentType === EnrolmentType.Internal) {
+      return t('events.eventCard.textEnrolments', {
+        count: enrolmentsCount || 0,
+      });
+    } else if (enrolmentType === EnrolmentType.External) {
+      return t('events.eventCard.textExternalEnrolments');
+    } else if (enrolmentType === EnrolmentType.Unenrollable) {
+      return t('events.eventCard.textUnenrollable');
     }
   };
 
@@ -84,9 +99,7 @@ const EventCard: React.FC<Props> = ({
           </div>
           <div className={styles.textWithIcon}>
             <IconUser />
-            {t('events.eventCard.textEnrolments', {
-              count: enrolmentsCount || 0,
-            })}
+            {getEnrolmentText()}
           </div>
           {/* TODO: Handle rest of the cases when there API support */}
           <div className={styles.textWithIcon}>

--- a/src/domain/event/eventCard/__tests__/EventCard.test.tsx
+++ b/src/domain/event/eventCard/__tests__/EventCard.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import * as React from 'react';
 
 import { PUBLICATION_STATUS } from '../../../events/constants';
+import { EnrolmentType } from '../../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
 import EventCard from '../EventCard';
 
 const defaultEventCardProps = {
@@ -11,6 +12,7 @@ const defaultEventCardProps = {
   occurrencesCount: 8,
   publicationStatus: PUBLICATION_STATUS.PUBLIC,
   image: 'test.url',
+  enrolmentType: EnrolmentType.Internal,
 };
 
 it('matches snapshot', () => {
@@ -48,4 +50,28 @@ it('displays correct texts and handles click', () => {
   expect(image).toHaveStyle(
     `background-image: url(${defaultEventCardProps.image});`
   );
+});
+
+it('displays event with external enrolment correctly', () => {
+  render(
+    <EventCard
+      {...defaultEventCardProps}
+      enrolmentType={EnrolmentType.External}
+    />
+  );
+  expect(screen.queryByText(/^2 ilmoittautunutta$/i)).not.toBeInTheDocument();
+  expect(
+    screen.queryByText(/ilmoittautuminen muulla sivustolla/i)
+  ).toBeInTheDocument();
+});
+
+it('displays unenrollable event correctly', () => {
+  render(
+    <EventCard
+      {...defaultEventCardProps}
+      enrolmentType={EnrolmentType.Unenrollable}
+    />
+  );
+  expect(screen.queryByText(/^2 ilmoittautunutta$/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/ei ilmoittautumista/i)).toBeInTheDocument();
 });

--- a/src/domain/event/eventCard/__tests__/EventCard.test.tsx
+++ b/src/domain/event/eventCard/__tests__/EventCard.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import * as React from 'react';
 
 import { PUBLICATION_STATUS } from '../../../events/constants';
-import { EnrolmentType } from '../../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from '../../../occurrence/constants';
 import EventCard from '../EventCard';
 
 const defaultEventCardProps = {

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -247,6 +247,7 @@ export const getEditEventPayload = ({
         : null),
       neededOccurrences:
         Number(existingEventValues.pEvent.neededOccurrences) ?? 1,
+      externalEnrolmentUrl: existingEventValues.pEvent.externalEnrolmentUrl,
       autoAcceptance: existingEventValues.pEvent.autoAcceptance ?? false,
       mandatoryAdditionalInformation: formValues.mandatoryAdditionalInformation,
     },

--- a/src/domain/events/EventsPage.tsx
+++ b/src/domain/events/EventsPage.tsx
@@ -17,6 +17,7 @@ import { ROUTES } from '../app/routes/constants';
 import EventCard from '../event/eventCard/EventCard';
 import { getEventFields } from '../event/utils';
 import { getSelectedOrganisation } from '../myProfile/utils';
+import { getEnrolmentType } from '../occurrence/utils';
 import ActiveOrganisationInfo from '../organisation/activeOrganisationInfo/ActiveOrganisationInfo';
 import { activeOrganisationSelector } from '../organisation/selector';
 import { EVENT_SORT_KEYS, PAGE_SIZE, PUBLICATION_STATUS } from './constants';
@@ -269,6 +270,7 @@ const Events: React.FC<{
           totalSeatsTakes = 0,
           publicationStatus,
         } = getEventFields(event, locale);
+        const enrolmentType = getEnrolmentType(event);
         return (
           <EventCard
             key={id || ''}
@@ -279,6 +281,7 @@ const Events: React.FC<{
             name={eventName}
             occurrencesCount={occurrences?.length || 0}
             publicationStatus={publicationStatus}
+            enrolmentType={enrolmentType}
             onClick={goToEventSummaryPage}
           />
         );

--- a/src/domain/occurrence/CreateOccurrencePage.tsx
+++ b/src/domain/occurrence/CreateOccurrencePage.tsx
@@ -40,10 +40,8 @@ import {
 import { useCreateOrUpdateVenueRequest } from '../event/eventForm/useEventFormSubmitRequests';
 import { isEditableEvent } from '../event/utils';
 import ActiveOrganisationInfo from '../organisation/activeOrganisationInfo/ActiveOrganisationInfo';
-import { defaultInitialValues } from './constants';
-import EnrolmentInfoFormPart, {
-  EnrolmentType,
-} from './enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { defaultInitialValues, EnrolmentType } from './constants';
+import EnrolmentInfoFormPart from './enrolmentInfoFormPart/EnrolmentInfoFormPart';
 import LocationFormPart from './locationFormPart/LocationFormPart';
 import styles from './occurrencePage.module.scss';
 import { OccurrencesFormHandleContext } from './OccurrencesFormHandleContext';

--- a/src/domain/occurrence/CreateOccurrencePage.tsx
+++ b/src/domain/occurrence/CreateOccurrencePage.tsx
@@ -41,7 +41,9 @@ import { useCreateOrUpdateVenueRequest } from '../event/eventForm/useEventFormSu
 import { isEditableEvent } from '../event/utils';
 import ActiveOrganisationInfo from '../organisation/activeOrganisationInfo/ActiveOrganisationInfo';
 import { defaultInitialValues } from './constants';
-import EnrolmentInfoFormPart from './enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import EnrolmentInfoFormPart, {
+  EnrolmentType,
+} from './enrolmentInfoFormPart/EnrolmentInfoFormPart';
 import LocationFormPart from './locationFormPart/LocationFormPart';
 import styles from './occurrencePage.module.scss';
 import { OccurrencesFormHandleContext } from './OccurrencesFormHandleContext';
@@ -51,11 +53,7 @@ import {
   OccurrenceSectionFormFields,
   TimeAndLocationFormFields,
 } from './types';
-import {
-  getEditEventPayload,
-  getFormEnrolmentType,
-  useBaseEventQuery,
-} from './utils';
+import { getEditEventPayload, useBaseEventQuery } from './utils';
 import ValidationSchema from './ValidationSchema';
 
 interface Params {
@@ -126,7 +124,20 @@ const CreateOccurrencePage: React.FC = () => {
           []
         );
 
-        const enrolmentType = getFormEnrolmentType(event);
+        const getEnrolmentType = (): EnrolmentType => {
+          if (event.pEvent.externalEnrolmentUrl) {
+            return EnrolmentType.External;
+          }
+          if (event.pEvent.enrolmentStart) {
+            return EnrolmentType.Internal;
+          }
+          if (event.location) {
+            return EnrolmentType.Unenrollable;
+          }
+          return EnrolmentType.Internal;
+        };
+
+        const enrolmentType = getEnrolmentType();
 
         setSelectedLanguages(eventLangs as Language[]);
         setInitialValues({

--- a/src/domain/occurrence/ValidationSchema.ts
+++ b/src/domain/occurrence/ValidationSchema.ts
@@ -7,7 +7,7 @@ import * as Yup from 'yup';
 import { DATETIME_FORMAT } from '../../common/components/datepicker/contants';
 import { isValidTime } from '../../utils/dateUtils';
 import { VALIDATION_MESSAGE_KEYS } from '../app/i18n/constants';
-import { EnrolmentType } from './enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from './constants';
 
 const ValidationSchema = Yup.object().shape({
   // infoUrl: Yup.string(),

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -1063,19 +1063,14 @@ describe('enrolment type selector', () => {
     renderComponent({
       mocks: [getEventMockedResponse({})],
     });
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', {
-          name: /ilmoittautuminen/i,
-        })
-      ).toBeInTheDocument();
+
+    await screen.findByRole('heading', {
+      name: /ilmoittautuminen/i,
     });
 
-    Object.values(radiosByType)
-      .flat()
-      .forEach((label) => {
-        expect(screen.getByText(label)).toBeInTheDocument();
-      });
+    Object.values(radiosByType).forEach((label) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
   });
 
   it.each((Object.keys(fieldSetsByType) as EnrolmentType[]).reverse())(
@@ -1092,11 +1087,10 @@ describe('enrolment type selector', () => {
       userEvent.click(screen.getByText(radiosByType[type]));
 
       const visibleFieldLabels = fieldSetsByType[type];
-      const hiddenFieldLabels = Object.values(
-        Object.assign({}, fieldSetsByType, {
-          [type]: [],
-        })
-      ).flat();
+      const hiddenFieldLabels = Object.values({
+        ...fieldSetsByType,
+        [type]: [],
+      }).flat();
 
       visibleFieldLabels.forEach((label) => {
         expect(screen.getByText(label)).toBeInTheDocument();

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -529,6 +529,7 @@ describe('location and enrolment info', () => {
         enrolmentEndDays: null,
         enrolmentStart: null,
         neededOccurrences: 1,
+        externalEnrolmentUrl: null,
         occurrences: fakeOccurrences(0),
       });
 

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -35,8 +35,8 @@ import {
   within,
 } from '../../../utils/testUtils';
 import { ROUTES } from '../../app/routes/constants';
-import CreateOccurrencePage from '../CreateOccurrencePage';
 import { EnrolmentType } from '../constants';
+import CreateOccurrencePage from '../CreateOccurrencePage';
 import { occurrencesFormTestId } from '../occurrencesFormPart/OccurrencesFormPart';
 
 configure({ defaultHidden: true });
@@ -1051,11 +1051,11 @@ describe('enrolment type selector', () => {
   const fieldSetsByType = {
     [EnrolmentType.Internal]: [
       /ilmoittautuminen alkaa/i,
-      /ilmoittautuminen sulkeutuu x päivää ennen tapahtuma\-aikaa/i,
+      /ilmoittautuminen sulkeutuu x päivää ennen tapahtuma-aikaa/i,
       /tarvittavat käyntikerrat/i,
       /vahvista ilmoittautumiset automaattisesti osallistujamäärän puitteissa/i,
     ],
-    [EnrolmentType.External]: [/www\-osoite ilmoittautumislomakkeelle/i],
+    [EnrolmentType.External]: [/www-osoite ilmoittautumislomakkeelle/i],
     [EnrolmentType.Unenrollable]: [] as RegExp[],
   };
 

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -36,7 +36,7 @@ import {
 } from '../../../utils/testUtils';
 import { ROUTES } from '../../app/routes/constants';
 import CreateOccurrencePage from '../CreateOccurrencePage';
-import { EnrolmentType } from '../enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from '../constants';
 import { occurrencesFormTestId } from '../occurrencesFormPart/OccurrencesFormPart';
 
 configure({ defaultHidden: true });

--- a/src/domain/occurrence/constants.ts
+++ b/src/domain/occurrence/constants.ts
@@ -1,8 +1,13 @@
-import { EnrolmentType } from './enrolmentInfoFormPart/EnrolmentInfoFormPart';
 import { TimeAndLocationFormFields } from './types';
 
 export enum OCCURRENCE_URL_PARAMS {
   ENROLMENT_UPDATED = 'enrolmentUpdated',
+}
+
+export enum EnrolmentType {
+  Internal = 'internal',
+  External = 'external',
+  Unenrollable = 'unenrollable',
 }
 
 export const defaultInitialValues: TimeAndLocationFormFields = {

--- a/src/domain/occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart.tsx
+++ b/src/domain/occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart.tsx
@@ -8,14 +8,9 @@ import CheckboxField from '../../../common/components/form/fields/CheckboxField'
 import DateInputField from '../../../common/components/form/fields/DateInputField';
 import RadiobuttonField from '../../../common/components/form/fields/RadiobuttonField';
 import TextInputField from '../../../common/components/form/fields/TextInputField';
+import { EnrolmentType } from '../constants';
 import styles from '../occurrencePage.module.scss';
 import { TimeAndLocationFormFields } from '../types';
-
-export enum EnrolmentType {
-  Internal = 'internal',
-  External = 'external',
-  Unenrollable = 'unenrollable',
-}
 
 const EnrolmentInfoFormPart: React.FC = () => {
   const { t } = useTranslation();

--- a/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
+++ b/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
@@ -22,7 +22,7 @@ import useLocale from '../../../hooks/useLocale';
 import { getEventFields } from '../../event/utils';
 import { OccurrenceFormContextSetter } from '../../occurrence/OccurrencesFormHandleContext';
 import PlaceText from '../../place/PlaceText';
-import { EnrolmentType } from '../enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from '../constants';
 import {
   OccurrenceSectionFormFields,
   TimeAndLocationFormFields,

--- a/src/domain/occurrence/types.ts
+++ b/src/domain/occurrence/types.ts
@@ -1,5 +1,5 @@
 import { SUPPORT_LANGUAGES } from '../../constants';
-import { EnrolmentType } from './enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from './constants';
 
 export interface OccurrenceSectionFormFields {
   startTime: Date | null;

--- a/src/domain/occurrence/utils.ts
+++ b/src/domain/occurrence/utils.ts
@@ -54,21 +54,6 @@ export const getEnrolmentType = (event: EventFieldsFragment): EnrolmentType => {
   return EnrolmentType.Unenrollable;
 };
 
-<<<<<<< HEAD
-export const getFormEnrolmentType = (
-  event: EventFieldsFragment
-): EnrolmentType => {
-  if (event.pEvent.externalEnrolmentUrl) {
-    return EnrolmentType.External;
-  }
-  if (event.pEvent.enrolmentStart || !event.location?.id) {
-    return EnrolmentType.Internal;
-  }
-  return EnrolmentType.Unenrollable;
-};
-=======
->>>>>>> cb70104 (feat(enrolment-type): events enrolment info differs on different enrolment type)
-
 export const getEventQueryVariables = (id: string) => ({
   id,
   include: ['location', 'keywords', 'audience', 'in_language'],

--- a/src/domain/occurrence/utils.ts
+++ b/src/domain/occurrence/utils.ts
@@ -10,7 +10,7 @@ import getLinkedEventsInternalId from '../../utils/getLinkedEventsInternalId';
 import omitTypenames from '../../utils/omitTypename';
 import { VIRTUAL_EVENT_LOCATION_ID } from '../event/constants';
 import { PUBLICATION_STATUS } from '../events/constants';
-import { EnrolmentType } from './enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from './constants';
 import {
   OccurrenceSectionFormFields,
   TimeAndLocationFormFields,

--- a/src/domain/occurrence/utils.ts
+++ b/src/domain/occurrence/utils.ts
@@ -45,15 +45,16 @@ export const getOccurrencePayload = ({
 };
 
 export const getEnrolmentType = (event: EventFieldsFragment): EnrolmentType => {
-  // if (event.externalEnrolmentUrl) {
-  //  return EnrolmentType.External;
-  // }
-  if (event.pEvent.enrolmentStart || !event.location?.id) {
+  if (event.pEvent.externalEnrolmentUrl) {
+    return EnrolmentType.External;
+  }
+  if (event.pEvent.enrolmentStart) {
     return EnrolmentType.Internal;
   }
   return EnrolmentType.Unenrollable;
 };
 
+<<<<<<< HEAD
 export const getFormEnrolmentType = (
   event: EventFieldsFragment
 ): EnrolmentType => {
@@ -65,6 +66,8 @@ export const getFormEnrolmentType = (
   }
   return EnrolmentType.Unenrollable;
 };
+=======
+>>>>>>> cb70104 (feat(enrolment-type): events enrolment info differs on different enrolment type)
 
 export const getEventQueryVariables = (id: string) => ({
   id,

--- a/src/domain/occurrences/occurrencesTable/ActionsDropdown.tsx
+++ b/src/domain/occurrences/occurrencesTable/ActionsDropdown.tsx
@@ -9,6 +9,7 @@ import TableDropdown, {
 import { OccurrenceFieldsFragment } from '../../../generated/graphql';
 import useHistory from '../../../hooks/useHistory';
 import { ROUTES } from '../../app/routes/constants';
+import { EnrolmentType } from '../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
 import styles from './actionsDropdown.module.scss';
 import CancelOccurrenceModal from './CancelOccurrenceModal';
 
@@ -18,6 +19,7 @@ export interface Props {
   onDelete?: (row: OccurrenceFieldsFragment) => void;
   onCancel?: (row: OccurrenceFieldsFragment, message?: string) => void;
   row: OccurrenceFieldsFragment;
+  enrolmentType: EnrolmentType;
 }
 
 const ActionsDropdown: React.FC<Props> = ({
@@ -25,6 +27,7 @@ const ActionsDropdown: React.FC<Props> = ({
   onDelete,
   onCancel,
   isEventDraft,
+  enrolmentType,
   row,
 }) => {
   const { t } = useTranslation();
@@ -74,7 +77,7 @@ const ActionsDropdown: React.FC<Props> = ({
   const showCancelAction = !row.cancelled && onCancel;
 
   const items = [
-    {
+    enrolmentType === EnrolmentType.Internal && {
       children: (
         <>
           <IconUser />

--- a/src/domain/occurrences/occurrencesTable/ActionsDropdown.tsx
+++ b/src/domain/occurrences/occurrencesTable/ActionsDropdown.tsx
@@ -9,7 +9,7 @@ import TableDropdown, {
 import { OccurrenceFieldsFragment } from '../../../generated/graphql';
 import useHistory from '../../../hooks/useHistory';
 import { ROUTES } from '../../app/routes/constants';
-import { EnrolmentType } from '../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from '../../occurrence/constants';
 import styles from './actionsDropdown.module.scss';
 import CancelOccurrenceModal from './CancelOccurrenceModal';
 

--- a/src/domain/occurrences/occurrencesTable/OccurrencesTable.tsx
+++ b/src/domain/occurrences/occurrencesTable/OccurrencesTable.tsx
@@ -15,6 +15,8 @@ import formatDate from '../../../utils/formatDate';
 import formatTimeRange from '../../../utils/formatTimeRange';
 import { ROUTES } from '../../app/routes/constants';
 import { PUBLICATION_STATUS } from '../../events/constants';
+import { EnrolmentType } from '../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { getEnrolmentType } from '../../occurrence/utils';
 import PlaceText from '../../place/PlaceText';
 import EnrolmentsBadge from '../enrolmentsBadge/EnrolmentsBadge';
 import ActionsDropdown from './ActionsDropdown';
@@ -74,6 +76,11 @@ const OccurrencesTable: React.FC<Props> = ({
       )
     );
   };
+
+  // EnrolmentType.Internal is the default enrolment type instead of undefined, because it makes the testing much easier
+  const enrolmentType = eventData?.event
+    ? getEnrolmentType(eventData.event)
+    : EnrolmentType.Internal;
 
   const columns = [
     {
@@ -168,6 +175,7 @@ const OccurrencesTable: React.FC<Props> = ({
       Header: t('occurrences.table.columnActions'),
       accessor: (row: OccurrenceFieldsFragment) => (
         <ActionsDropdown
+          enrolmentType={enrolmentType}
           eventId={eventId}
           isEventDraft={isEventDraft}
           onDelete={onDelete}

--- a/src/domain/occurrences/occurrencesTable/OccurrencesTable.tsx
+++ b/src/domain/occurrences/occurrencesTable/OccurrencesTable.tsx
@@ -15,7 +15,7 @@ import formatDate from '../../../utils/formatDate';
 import formatTimeRange from '../../../utils/formatTimeRange';
 import { ROUTES } from '../../app/routes/constants';
 import { PUBLICATION_STATUS } from '../../events/constants';
-import { EnrolmentType } from '../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from '../../occurrence/constants';
 import { getEnrolmentType } from '../../occurrence/utils';
 import PlaceText from '../../place/PlaceText';
 import EnrolmentsBadge from '../enrolmentsBadge/EnrolmentsBadge';

--- a/src/domain/occurrences/occurrencesTable/__tests__/ActionsDropdown.test.tsx
+++ b/src/domain/occurrences/occurrencesTable/__tests__/ActionsDropdown.test.tsx
@@ -5,6 +5,7 @@ import { tableDropdownTestId } from '../../../../common/components/tableDropdown
 import { fakeOccurrence } from '../../../../utils/mockDataUtils';
 import { render, screen, userEvent } from '../../../../utils/testUtils';
 import { ROUTES } from '../../../app/routes/constants';
+import { EnrolmentType } from '../../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
 import ActionsDropdown, { Props } from '../ActionsDropdown';
 
 const eventId = 'testEventId123';
@@ -15,6 +16,7 @@ const mockOccurrence = fakeOccurrence({ id: occurrenceId });
 const renderComponent = (props?: Partial<Props>) => {
   return render(
     <ActionsDropdown
+      enrolmentType={EnrolmentType.Internal}
       eventId={eventId}
       isEventDraft
       onDelete={jest.fn()}
@@ -60,6 +62,16 @@ it('navigates correctly from actions', () => {
     )}`
   );
 });
+
+it.each([EnrolmentType.External, EnrolmentType.Unenrollable])(
+  'does not render enrollments link when enrolment type is not internal',
+  (enrolmentType) => {
+    renderComponent({ enrolmentType: enrolmentType });
+    expect(
+      screen.queryByRole('menuitem', { name: 'Ilmoittautuneet' })
+    ).not.toBeInTheDocument();
+  }
+);
 
 it('renders cancel modal and cancel functionality works', () => {
   const onCancelMock = jest.fn();

--- a/src/domain/occurrences/occurrencesTable/__tests__/ActionsDropdown.test.tsx
+++ b/src/domain/occurrences/occurrencesTable/__tests__/ActionsDropdown.test.tsx
@@ -5,7 +5,7 @@ import { tableDropdownTestId } from '../../../../common/components/tableDropdown
 import { fakeOccurrence } from '../../../../utils/mockDataUtils';
 import { render, screen, userEvent } from '../../../../utils/testUtils';
 import { ROUTES } from '../../../app/routes/constants';
-import { EnrolmentType } from '../../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from '../../../occurrence/constants';
 import ActionsDropdown, { Props } from '../ActionsDropdown';
 
 const eventId = 'testEventId123';

--- a/src/domain/occurrences/occurrencesTableReadOnly/OccurrencesTableSummary.tsx
+++ b/src/domain/occurrences/occurrencesTableReadOnly/OccurrencesTableSummary.tsx
@@ -50,62 +50,60 @@ const OccurrencesTableSummary: React.FC<Props> = ({
   const enrolmentType = eventData?.event
     ? getEnrolmentType(eventData.event)
     : EnrolmentType.Internal;
+  const isInternalEnrolment = EnrolmentType.Internal === enrolmentType;
 
-  const enrolmentColumns =
-    EnrolmentType.Internal === enrolmentType
-      ? [
-          {
-            Header: t('occurrences.table.columnAmountOfSeats'),
-            accessor: (row: OccurrenceFieldsFragment) => {
-              if (row.seatType === OccurrenceSeatType.EnrolmentCount) {
-                return t('occurrenceDetails.textAmountOfGroups', {
-                  count: row.amountOfSeats,
-                });
-              }
-              return row.amountOfSeats;
-            },
-            id: 'amountOfSeats',
-          },
-          {
-            Header: t('occurrences.table.columnEnrolmentStarts'),
-            accessor: (row: OccurrenceFieldsFragment) =>
-              eventData?.event?.pEvent?.enrolmentStart
-                ? formatDate(new Date(eventData?.event?.pEvent?.enrolmentStart))
-                : '',
-            id: 'enrolmentStarts',
-          },
-          {
-            Header: (
-              <>
-                <div>{t('occurrences.table.columnEnrolments')}</div>
-                <div className={styles.enrolmentsInfoText}>
-                  {t('occurrences.table.columnEnrolmentsHelper')}
-                </div>
-              </>
-            ),
-            accessor: (row: OccurrenceFieldsFragment) => {
-              if (row.cancelled) {
-                return (
-                  <span className={styles.cancelledText}>
-                    {t('occurrences.status.cancelled')}
-                  </span>
-                );
-              }
-              if (row.seatsTaken != null && row.seatsApproved != null) {
-                return (
-                  <EnrolmentsBadge
-                    approvedSeatsCount={row.seatsApproved}
-                    pendingSeatsCount={row.seatsTaken - row.seatsApproved}
-                    isOccurrenceFull={row.remainingSeats === 0}
-                  />
-                );
-              }
-              return null;
-            },
-            id: 'enrolments',
-          },
-        ]
-      : [];
+  const enrolmentColumns = [
+    {
+      Header: t('occurrences.table.columnAmountOfSeats'),
+      accessor: (row: OccurrenceFieldsFragment) => {
+        if (row.seatType === OccurrenceSeatType.EnrolmentCount) {
+          return t('occurrenceDetails.textAmountOfGroups', {
+            count: row.amountOfSeats,
+          });
+        }
+        return row.amountOfSeats;
+      },
+      id: 'amountOfSeats',
+    },
+    {
+      Header: t('occurrences.table.columnEnrolmentStarts'),
+      accessor: (row: OccurrenceFieldsFragment) =>
+        eventData?.event?.pEvent?.enrolmentStart
+          ? formatDate(new Date(eventData?.event?.pEvent?.enrolmentStart))
+          : '',
+      id: 'enrolmentStarts',
+    },
+    {
+      Header: (
+        <>
+          <div>{t('occurrences.table.columnEnrolments')}</div>
+          <div className={styles.enrolmentsInfoText}>
+            {t('occurrences.table.columnEnrolmentsHelper')}
+          </div>
+        </>
+      ),
+      accessor: (row: OccurrenceFieldsFragment) => {
+        if (row.cancelled) {
+          return (
+            <span className={styles.cancelledText}>
+              {t('occurrences.status.cancelled')}
+            </span>
+          );
+        }
+        if (row.seatsTaken != null && row.seatsApproved != null) {
+          return (
+            <EnrolmentsBadge
+              approvedSeatsCount={row.seatsApproved}
+              pendingSeatsCount={row.seatsTaken - row.seatsApproved}
+              isOccurrenceFull={row.remainingSeats === 0}
+            />
+          );
+        }
+        return null;
+      },
+      id: 'enrolments',
+    },
+  ];
 
   const columns = [
     {
@@ -128,7 +126,7 @@ const OccurrencesTableSummary: React.FC<Props> = ({
       },
       id: 'place',
     },
-    ...enrolmentColumns,
+    ...(isInternalEnrolment ? enrolmentColumns : []),
     {
       Header: t('occurrences.table.columnActions'),
       accessor: (row: OccurrenceFieldsFragment) => (

--- a/src/domain/occurrences/occurrencesTableReadOnly/OccurrencesTableSummary.tsx
+++ b/src/domain/occurrences/occurrencesTableReadOnly/OccurrencesTableSummary.tsx
@@ -46,7 +46,10 @@ const OccurrencesTableSummary: React.FC<Props> = ({
     );
   };
 
-  const enrolmentType = eventData?.event && getEnrolmentType(eventData.event);
+  // EnrolmentType.Internal is the default enrolment type instead of undefined, because it makes the testing much easier
+  const enrolmentType = eventData?.event
+    ? getEnrolmentType(eventData.event)
+    : EnrolmentType.Internal;
 
   const enrolmentColumns =
     EnrolmentType.Internal === enrolmentType

--- a/src/domain/occurrences/occurrencesTableReadOnly/OccurrencesTableSummary.tsx
+++ b/src/domain/occurrences/occurrencesTableReadOnly/OccurrencesTableSummary.tsx
@@ -13,7 +13,7 @@ import useLocale from '../../../hooks/useLocale';
 import formatDate from '../../../utils/formatDate';
 import formatTimeRange from '../../../utils/formatTimeRange';
 import { ROUTES } from '../../app/routes/constants';
-import { EnrolmentType } from '../../occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart';
+import { EnrolmentType } from '../../occurrence/constants';
 import { getEnrolmentType } from '../../occurrence/utils';
 import PlaceText from '../../place/PlaceText';
 import EnrolmentsBadge from '../enrolmentsBadge/EnrolmentsBadge';

--- a/src/domain/occurrences/occurrencesTableReadOnly/OccurrencesTableSummary.tsx
+++ b/src/domain/occurrences/occurrencesTableReadOnly/OccurrencesTableSummary.tsx
@@ -132,7 +132,12 @@ const OccurrencesTableSummary: React.FC<Props> = ({
     {
       Header: t('occurrences.table.columnActions'),
       accessor: (row: OccurrenceFieldsFragment) => (
-        <ActionsDropdown eventId={eventId} onCancel={onCancel} row={row} />
+        <ActionsDropdown
+          eventId={eventId}
+          onCancel={onCancel}
+          row={row}
+          enrolmentType={enrolmentType}
+        />
       ),
       id: 'actions',
       rowClickDisabled: true,

--- a/src/domain/occurrences/occurrencesTableReadOnly/__tests__/OccurrencesTableSummary.test.tsx
+++ b/src/domain/occurrences/occurrencesTableReadOnly/__tests__/OccurrencesTableSummary.test.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
 
+import { PalvelutarjotinEventNode } from '../../../../generated/graphql';
 import formatDate from '../../../../utils/formatDate';
 import formatTimeRange from '../../../../utils/formatTimeRange';
-import { fakeOccurrence, fakePEvent } from '../../../../utils/mockDataUtils';
+import {
+  fakeEvent,
+  fakeOccurrence,
+  fakePEvent,
+} from '../../../../utils/mockDataUtils';
 import { render, screen } from '../../../../utils/testUtils';
 import OccurrencesTableSummary, { Props } from '../OccurrencesTableSummary';
 
@@ -50,4 +55,21 @@ it('show occurrence data in the table in correct format', () => {
     name: occurrenceRowText,
   });
   expect(occurrenceRow).toBeInTheDocument();
+});
+
+it('show occurrence data in the table in correct format when enrolments are not done internally', () => {
+  renderComponent({
+    eventData: {
+      event: fakeEvent({
+        pEvent: fakePEvent({
+          enrolmentStart: null,
+          externalEnrolmentUrl: null,
+        }),
+      }),
+    },
+  });
+  expect(screen.getByText(/Tapahtumapaikka/i)).toBeInTheDocument();
+  expect(screen.getByText(/Toiminnot/i)).toBeInTheDocument();
+  expect(screen.queryByText(/Ilm. alkaa/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Ilmoittautuneita/i)).not.toBeInTheDocument();
 });

--- a/src/domain/occurrences/occurrencesTableReadOnly/__tests__/OccurrencesTableSummary.test.tsx
+++ b/src/domain/occurrences/occurrencesTableReadOnly/__tests__/OccurrencesTableSummary.test.tsx
@@ -57,7 +57,7 @@ it('show occurrence data in the table in correct format', () => {
   expect(occurrenceRow).toBeInTheDocument();
 });
 
-it('show occurrence data in the table in correct format when enrolments are not done internally', () => {
+it('does not render enrolment info when enrolments are not done internally', () => {
   renderComponent({
     eventData: {
       event: fakeEvent({

--- a/src/domain/occurrences/occurrencesTableReadOnly/__tests__/OccurrencesTableSummary.test.tsx
+++ b/src/domain/occurrences/occurrencesTableReadOnly/__tests__/OccurrencesTableSummary.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { PalvelutarjotinEventNode } from '../../../../generated/graphql';
 import formatDate from '../../../../utils/formatDate';
 import formatTimeRange from '../../../../utils/formatTimeRange';
 import {

--- a/src/domain/occurrences/occurrencesTableReadOnly/__tests__/OccurrencesTableSummary.test.tsx
+++ b/src/domain/occurrences/occurrencesTableReadOnly/__tests__/OccurrencesTableSummary.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import formatDate from '../../../../utils/formatDate';
 import formatTimeRange from '../../../../utils/formatTimeRange';
-import { fakeOccurrence } from '../../../../utils/mockDataUtils';
+import { fakeOccurrence, fakePEvent } from '../../../../utils/mockDataUtils';
 import { render, screen } from '../../../../utils/testUtils';
 import OccurrencesTableSummary, { Props } from '../OccurrencesTableSummary';
 
@@ -21,6 +21,10 @@ const mockOccurrence = fakeOccurrence({
   endTime: endTime,
   amountOfSeats: 240,
   placeId: null,
+  pEvent: fakePEvent({
+    id: 'UGFsdmVsdXRhcmpvdGluRXZlbnROb2RlOjcw',
+    enrolmentStart: new Date(),
+  }),
 });
 
 const renderComponent = (props?: Partial<Props>) => {

--- a/src/test/CreateOccurrencePageTestUtils.ts
+++ b/src/test/CreateOccurrencePageTestUtils.ts
@@ -370,7 +370,7 @@ export const getUpdateEventMockResponse = ({
   enrolmentEndDays: number;
   enrolmentStart: string;
   neededOccurrences: number;
-  externalEnrolmentUrl?: string;
+  externalEnrolmentUrl?: string | null;
   languages?: Languages[];
 }): MockedResponse => ({
   request: {
@@ -406,6 +406,7 @@ export const getEventMockedResponse = ({
   autoAcceptance = true,
   enrolmentEndDays = null,
   enrolmentStart = null,
+  externalEnrolmentUrl = null,
   neededOccurrences = 1,
   languages = ['fi'],
   occurrences,
@@ -414,6 +415,7 @@ export const getEventMockedResponse = ({
   autoAcceptance?: boolean;
   enrolmentEndDays?: number | null;
   enrolmentStart?: string | null;
+  externalEnrolmentUrl?: string | null;
   neededOccurrences?: number;
   languages?: Languages[];
   occurrences?: OccurrenceNodeConnection;
@@ -430,6 +432,7 @@ export const getEventMockedResponse = ({
     autoAcceptance,
     enrolmentEndDays,
     enrolmentStart,
+    externalEnrolmentUrl,
     location: location
       ? fakePlace({
           id: placeId,
@@ -446,6 +449,7 @@ const getEventResponse = ({
   autoAcceptance,
   enrolmentEndDays,
   enrolmentStart,
+  externalEnrolmentUrl,
   neededOccurrences,
   languages = ['fi'],
   occurrences,
@@ -454,6 +458,7 @@ const getEventResponse = ({
   autoAcceptance: boolean;
   enrolmentEndDays: number;
   enrolmentStart: string;
+  externalEnrolmentUrl: string;
   neededOccurrences: number;
   languages?: Languages[];
   occurrences?: OccurrenceNodeConnection;
@@ -514,6 +519,7 @@ const getEventResponse = ({
         autoAcceptance,
         enrolmentEndDays,
         enrolmentStart,
+        externalEnrolmentUrl,
         neededOccurrences,
         mandatoryAdditionalInformation: false,
         occurrences: occurrences ?? fakeOccurrences(),
@@ -538,8 +544,8 @@ const getEditEventVariables = ({
   autoAcceptance: boolean;
   enrolmentEndDays: number;
   enrolmentStart: string;
-  externalEnrolmentUrl?: string;
   neededOccurrences: number;
+  externalEnrolmentUrl?: string | null;
   languages?: Languages[];
 }) => ({
   event: {
@@ -583,10 +589,10 @@ const getEditEventVariables = ({
       contactPhoneNumber: contactPhoneNumber,
       enrolmentEndDays,
       enrolmentStart: enrolmentStart ? new Date(enrolmentStart) : null,
+      externalEnrolmentUrl,
       neededOccurrences,
       autoAcceptance,
       mandatoryAdditionalInformation: false,
-      externalEnrolmentUrl,
     },
   },
 });

--- a/src/test/EventPageTestUtil.ts
+++ b/src/test/EventPageTestUtil.ts
@@ -158,6 +158,7 @@ const editEventVariables = {
       contactPhoneNumber: contactPhoneNumber,
       enrolmentEndDays: 3,
       enrolmentStart: '2020-08-13T00:45:00.000Z',
+      externalEnrolmentUrl: null,
       neededOccurrences: 3,
       mandatoryAdditionalInformation: mandatoryAdditionalInformation,
     },

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -281,7 +281,6 @@ export const fakePEvent = (
   autoAcceptance: false,
   nextOccurrenceDatetime: '',
   lastOccurrenceDatetime: '',
-  externalEnrolmentUrl: null,
   mandatoryAdditionalInformation: false,
   __typename: 'PalvelutarjotinEventNode',
   ...overrides,
@@ -341,7 +340,7 @@ export const fakeLanguage = (
 });
 
 export const fakeOccurrence = (
-  overrides?: Partial<OccurrenceNode>,
+  overrides?: Partial<OccurrenceNode>
 ): OccurrenceNode => ({
   id: faker.datatype.uuid(),
   pEvent: {

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -271,6 +271,7 @@ export const fakePEvent = (
   contactPhoneNumber: '1233211234',
   enrolmentEndDays: 3,
   enrolmentStart: '2020-07-13T06:00:00+00:00',
+  externalEnrolmentUrl: null,
   neededOccurrences: 3,
   organisation: fakeOrganisation(),
   occurrences: fakeOccurrences(),
@@ -340,7 +341,7 @@ export const fakeLanguage = (
 });
 
 export const fakeOccurrence = (
-  overrides?: Partial<OccurrenceNode>
+  overrides?: Partial<OccurrenceNode>,
 ): OccurrenceNode => ({
   id: faker.datatype.uuid(),
   pEvent: {


### PR DESCRIPTION
The enrolment information is shown only If the event's enrolment type is internal. If the enrolments are done externally or the event is unenrollable, enrolment status info won't be rendered. In event card also shows the enrolment type.

PT-849 PT-1102.