### PR TITLE
feat: filter events by profile places

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # testcafe screenshots
-/screenshot
+/screenshots
 
 # ItelliJ
 *.iml

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -470,8 +470,8 @@
       "labelPlaces": "Places",
       "placeholderPlaces": "Search places...",
       "placesToggleButtonAriaLabel": "Open dropdown",
-      "placesClearButtonAriaLabel": "Delete all places",
-      "placesSelectedItemRemoveButtonAriaLabel": "Delete place"
+      "placesClearButtonAriaLabel": "Clear place selections",
+      "placesSelectedItemRemoveButtonAriaLabel": "Remove place"
     },
     "textEventCount": "{{count}} pcs",
     "textNoComingEvents": "No events with coming event times",

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -464,7 +464,15 @@
         "tomorrow": "Tomorrow at {{time}}"
       }
     },
-    "placeholderSearch": "Search",
+    "search": {
+      "placeholderSearch": "Search",
+      "labelSearch": "Search",
+      "labelPlaces": "Places",
+      "placeholderPlaces": "Search places...",
+      "placesToggleButtonAriaLabel": "Open dropdown",
+      "placesClearButtonAriaLabel": "Delete all places",
+      "placesSelectedItemRemoveButtonAriaLabel": "Delete place"
+    },
     "textEventCount": "{{count}} pcs",
     "textNoComingEvents": "No events with coming event times",
     "title": "Events",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -476,7 +476,7 @@
       "labelPlaces": "Paikat",
       "placeholderPlaces": "Hae paikkoja...",
       "placesToggleButtonAriaLabel": "Avaa valikko",
-      "placesClearButtonAriaLabel": "Poista kaikki paikat",
+      "placesClearButtonAriaLabel": "Tyhjennä kaikki paikat",
       "placesSelectedItemRemoveButtonAriaLabel": "Poista paikka"
     },
     "textEventCount": "{{count}} kpl",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -470,7 +470,15 @@
         "tomorrow": "Huomenna klo {{time}}"
       }
     },
-    "placeholderSearch": "Haku",
+    "search": {
+      "placeholderSearch": "Haku",
+      "labelSearch": "Haku",
+      "labelPlaces": "Paikat",
+      "placeholderPlaces": "Hae paikkoja...",
+      "placesToggleButtonAriaLabel": "Avaa valikko",
+      "placesClearButtonAriaLabel": "Poista kaikki paikat",
+      "placesSelectedItemRemoveButtonAriaLabel": "Poista paikka"
+    },
     "textEventCount": "{{count}} kpl",
     "textNoComingEvents": "Ei tapahtumia joissa on tulevia tapahtumia-aikoja",
     "title": "Tapahtumat",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -471,7 +471,16 @@
         "tomorrow": "Imorgon kl {{time}}"
       }
     },
-    "placeholderSearch": "Sök",
+    "search": {
+      "placeholderSearch": "Sök",
+      "labelSearch": "Sök",
+      "labelPlaces": "(SV)Places",
+      "placeholderPlaces": "(SV)Search places...",
+      "placesToggleButtonAriaLabel": "(SV)Open dropdown",
+      "placesClearButtonAriaLabel": "(SV)Delete all places",
+      "placesSelectedItemRemoveButtonAriaLabel": "(SV)Delete place"
+    },
+
     "textEventCount": "{{count}} st",
     "textNoComingEvents": "Inga evenemang med kommande evenemangtider",
     "title": "Evenemang",

--- a/src/domain/events/__tests__/EventsPage.test.tsx
+++ b/src/domain/events/__tests__/EventsPage.test.tsx
@@ -296,7 +296,7 @@ test('events can be searched with places from user profile', async () => {
   expect(screen.queryByText(events[0].eventDescription)).toBeInTheDocument();
 
   const clearPlacesButton = screen.getByRole('button', {
-    name: /poista kaikki paikat/i,
+    name: /tyhjennä kaikki paikat/i,
   });
   userEvent.click(clearPlacesButton);
 

--- a/src/domain/events/eventsPage.module.scss
+++ b/src/domain/events/eventsPage.module.scss
@@ -46,7 +46,7 @@
     grid-gap: var(--grid-gap);
 
     @include respond_above(sm) {
-      grid-template-columns: 1fr var(--width-input);
+      grid-template-columns: var(--width-input) 1fr auto;
     }
   }
 

--- a/src/hooks/useProfilePlaces.ts
+++ b/src/hooks/useProfilePlaces.ts
@@ -1,0 +1,68 @@
+import { useApolloClient } from '@apollo/client';
+import React from 'react';
+
+import {
+  PlaceDocument,
+  PlaceFieldsFragment,
+  PlaceQuery,
+  PlaceQueryVariables,
+  useMyProfileQuery,
+} from '../generated/graphql';
+import useIsMounted from './useIsMounted';
+
+const useProfilePlaces = () => {
+  const [places, setPlaces] = React.useState<PlaceFieldsFragment[] | null>(
+    null
+  );
+  const isMounted = useIsMounted();
+  const [loadingPlaces, setLoadingPlaces] = React.useState<boolean>(true);
+  const { data: profileData, loading: loadingMyProfile } = useMyProfileQuery();
+  const apolloClient = useApolloClient();
+  const profile = profileData?.myProfile;
+
+  React.useEffect(() => {
+    let cancel = false;
+
+    const fetchPlaces = async () => {
+      const placeIds = profile?.placeIds;
+      if (placeIds) {
+        setLoadingPlaces(true);
+        try {
+          const placeResponses = await Promise.all(
+            placeIds.map((placeId) => {
+              return apolloClient.query<PlaceQuery, PlaceQueryVariables>({
+                query: PlaceDocument,
+                variables: {
+                  id: placeId,
+                },
+              });
+            })
+          );
+          const places = placeResponses
+            .map((placeResponse) => placeResponse.data.place!)
+            .filter((p) => p);
+
+          if (!cancel && isMounted.current) {
+            setPlaces(places);
+            setLoadingPlaces(false);
+          }
+        } catch (e) {
+          setLoadingPlaces(false);
+        }
+      }
+    };
+
+    if (profile) {
+      fetchPlaces();
+    }
+
+    return () => {
+      setLoadingPlaces(false);
+      cancel = true;
+    };
+  }, [profile, apolloClient, isMounted]);
+
+  return { places, loading: loadingPlaces || loadingMyProfile };
+};
+
+export default useProfilePlaces;


### PR DESCRIPTION
## Description :sparkles:

- Add ability to filter events by locations that are in the profile.

## Issues :bug:
### Closes :no_good_woman:
**[PT-1203](https://helsinkisolutionoffice.atlassian.net/browse/PT-1203):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️
`yarn test EventsPage`

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:
<img width="1377" alt="Screenshot 2021-09-22 at 17 48 04" src="https://user-images.githubusercontent.com/15219142/134366416-eb387c0e-26bc-4618-944f-fbcc9e05cb6f.png">

## Additional notes :spiral_notepad: