### PR TITLE
fix: hide min and max fields when not internal enrolment + improve tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ yarn-error.log*
 
 # ItelliJ
 *.iml
+
+screenshots

--- a/.testcaferc.json
+++ b/.testcaferc.json
@@ -2,6 +2,7 @@
   "clientScripts": [
     { "module": "@testing-library/dom/dist/@testing-library/dom.umd.js" }
   ],
+  "skipJsErrors": true,
   "tsConfigPath": "./tsconfig.testcafe.json",
   "screenshots": {
     "takeOnFails": true

--- a/src/domain/occurrence/CreateOccurrencePage.tsx
+++ b/src/domain/occurrence/CreateOccurrencePage.tsx
@@ -273,9 +273,9 @@ const CreateOccurrencePage: React.FC = () => {
 
   const handleGoToPublishingClick: React.MouseEventHandler<HTMLButtonElement> =
     () => {
+      // after saving, event data is refetched and it should include at least 1 ocurrences
       const { pEvent: { occurrences = undefined } = {} } =
         eventDataRef.current?.event ?? {};
-
       const requiredFieldsSchema = Yup.object().shape({
         occurrences: Yup.array().min(
           1,

--- a/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
+++ b/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
@@ -205,7 +205,7 @@ const OccurrenceForm: React.FC<{
     setFieldValue,
     values: { startTime, endTime, oneGroupFills },
   } = useFormikContext<OccurrenceSectionFormFields>();
-  const showGroupSizeInputs = enrolmentType !== EnrolmentType.External;
+  const showGroupSizeInputs = enrolmentType === EnrolmentType.Internal;
 
   const languageOptions = React.useMemo(
     () => getOrderedLanguageOptions(t),


### PR DESCRIPTION
## Description :sparkles:

- Hide min and max fields when event doesn't have internal enrolment

## Issues :bug:
### Closes :no_good_woman:
**[PT-1215](https://helsinkisolutionoffice.atlassian.net/browse/PT-1215):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: