### PR TITLE
fix: hide also seats input when not internal enrolment

### DIFF
--- a/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
+++ b/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
@@ -85,8 +85,14 @@ const OccurrencesForm: React.FC<{
   }, [location]);
 
   const validationSchema = React.useMemo(
-    () => getValidationSchema({ isVirtual, enrolmentEndDays, enrolmentStart }),
-    [enrolmentEndDays, enrolmentStart, isVirtual]
+    () =>
+      getValidationSchema({
+        isVirtual,
+        enrolmentEndDays,
+        enrolmentStart,
+        enrolmentType,
+      }),
+    [enrolmentEndDays, enrolmentStart, isVirtual, enrolmentType]
   );
   const eventVariables = getEventQueryVariables(eventId ?? '');
 
@@ -217,6 +223,7 @@ const OccurrenceForm: React.FC<{
     if (!showGroupSizeInputs) {
       setFieldValue('minGroupSize', '');
       setFieldValue('maxGroupSize', '');
+      setFieldValue('amountOfSeats', '');
     }
   }, [showGroupSizeInputs, setFieldValue]);
 
@@ -278,18 +285,18 @@ const OccurrenceForm: React.FC<{
           options={languageOptions}
         />
         {/* divs are here to avoid styling problem with HDS */}
-        <div>
-          <Field
-            label={t('eventOccurrenceForm.labelAmountOfSeats')}
-            name="amountOfSeats"
-            disabled={oneGroupFills}
-            component={TextInputField}
-            min={0}
-            type="number"
-          />
-        </div>
         {showGroupSizeInputs && (
           <>
+            <div>
+              <Field
+                label={t('eventOccurrenceForm.labelAmountOfSeats')}
+                name="amountOfSeats"
+                disabled={oneGroupFills}
+                component={TextInputField}
+                min={0}
+                type="number"
+              />
+            </div>
             <div>
               <Field
                 label={t('eventOccurrenceForm.labelGroupSizeMin')}

--- a/src/domain/occurrence/occurrencesFormPart/ValidationSchema.ts
+++ b/src/domain/occurrence/occurrencesFormPart/ValidationSchema.ts
@@ -7,6 +7,7 @@ import { MessageParams } from 'yup/lib/types';
 
 import { isInFuture } from '../../../utils/dateUtils';
 import { VALIDATION_MESSAGE_KEYS } from '../../app/i18n/constants';
+import { EnrolmentType } from '../constants';
 
 const addMinValidationMessage = (
   param: {
@@ -56,10 +57,12 @@ const getValidationSchema = ({
   isVirtual,
   enrolmentEndDays,
   enrolmentStart,
+  enrolmentType,
 }: {
   isVirtual?: boolean;
   enrolmentEndDays?: string | number;
   enrolmentStart?: Date | null;
+  enrolmentType: EnrolmentType;
 }) =>
   Yup.object().shape({
     occurrenceLocation: isVirtual
@@ -86,9 +89,12 @@ const getValidationSchema = ({
     languages: Yup.array()
       .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
       .min(1, VALIDATION_MESSAGE_KEYS.STRING_REQUIRED),
-    amountOfSeats: Yup.number()
-      .required(VALIDATION_MESSAGE_KEYS.NUMBER_REQUIRED)
-      .min(1, addMinValidationMessage),
+    amountOfSeats:
+      enrolmentType === EnrolmentType.Internal
+        ? Yup.number()
+            .required(VALIDATION_MESSAGE_KEYS.NUMBER_REQUIRED)
+            .min(1, addMinValidationMessage)
+        : Yup.number(),
     minGroupSize: Yup.number()
       .min(1, addMinValidationMessage)
       .when(


### PR DESCRIPTION
## Description :sparkles:

- Hide also seats input when not internal enrolments

## Issues :bug:
### Closes :no_good_woman:
**[PT-1215](https://helsinkisolutionoffice.atlassian.net/browse/PT-1215):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: