### PR TITLE
PT-1228 | Add ability to edit occurrences (add/delete)

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -656,6 +656,10 @@
     "textGroupInfo": "group size {{minGroupSize}}–{{maxGroupSize}}",
     "labelLanguages": "Language"
   },
+  "editOccurrencesPage": {
+    "buttonBackToSummary": "EN: Takaisin tapahtuman tietoihin",
+    "titleEditOccurrences": "EN: Muokkaa tapahtuma-aikoja"
+  },
   "occurrences": {
     "actionsDropdown": {
       "menuItemDelete": "Delete",

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -675,6 +675,7 @@
     "buttonShowMore": "Show more occurrences",
     "count": "{{count}} pcs",
     "deleteError": "Failed to delete event time",
+    "deleteSuccess": "EN: Tapahtuma-aika poistettu",
     "deleteModal": {
       "buttonDelete": "Delete event time",
       "text1": "Are you sure you want to delete the event time?",
@@ -687,7 +688,7 @@
       "note2": "Enrolments to this occurrence will be canceled and a message will be sent to enrollees."
     },
     "cancelError": "Canceling occurrence failed",
-    "cancelErrorSuccess": "Occurrence canceled",
+    "cancelSuccess": "Occurrence canceled",
     "downloadCalendarError": "Error while importing to calendar",
     "pageTitle": "Event times",
     "status": {

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -657,8 +657,8 @@
     "labelLanguages": "Language"
   },
   "editOccurrencesPage": {
-    "buttonBackToSummary": "EN: Takaisin tapahtuman tietoihin",
-    "titleEditOccurrences": "EN: Muokkaa tapahtuma-aikoja"
+    "buttonBackToSummary": "Back to event details",
+    "titleEditOccurrences": "Edit occurrences"
   },
   "occurrences": {
     "actionsDropdown": {
@@ -675,7 +675,7 @@
     "buttonShowMore": "Show more occurrences",
     "count": "{{count}} pcs",
     "deleteError": "Failed to delete event time",
-    "deleteSuccess": "EN: Tapahtuma-aika poistettu",
+    "deleteSuccess": "Occurrence deleted successfully",
     "deleteModal": {
       "buttonDelete": "Delete event time",
       "text1": "Are you sure you want to delete the event time?",
@@ -684,7 +684,7 @@
     },
     "cancelModal": {
       "title": "Cancel occurrence",
-      "note1": "Are you sure that you want to delete se selected occurrence?",
+      "note1": "Are you sure that you want to cancel the selected occurrence?",
       "note2": "Enrolments to this occurrence will be canceled and a message will be sent to enrollees."
     },
     "cancelError": "Canceling occurrence failed",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -662,6 +662,10 @@
     "textGroupInfo": "ryhmän koko {{minGroupSize}}–{{maxGroupSize}}",
     "labelLanguages": "Kieli"
   },
+  "editOccurrencesPage": {
+    "buttonBackToSummary": "Takaisin tapahtuman tietoihin",
+    "titleEditOccurrences": "Muokkaa tapahtuma-aikoja"
+  },
   "occurrences": {
     "actionsDropdown": {
       "menuItemDelete": "Poista",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -681,6 +681,7 @@
     "buttonShowMore": "Näytä lisää tapahtuma-aikoja",
     "count": "{{count}} kpl",
     "deleteError": "Tapahtuma-ajan poistaminen epäonnistui",
+    "deleteSuccess": "Tapahtuma-aika poistettu",
     "deleteModal": {
       "buttonDelete": "Poista tapahtuma-aika",
       "text1": "Oletko varma että haluat poistaa tapahtuma-ajan?",
@@ -693,7 +694,7 @@
       "note2": "Tähän tapahtuma-aikaan ilmoittautuneiden ilmoittautumiset perutaan ja heille lähetetään peruutusviesti"
     },
     "cancelError": "Tapahtuma-ajan peruminen epäonnistui",
-    "cancelErrorSuccess": "Tapahtuma-aika peruutettu",
+    "cancelSuccess": "Tapahtuma-aika peruutettu",
     "downloadCalendarError": "Virhe ladattaessa tapahtumaa kalenteriin",
     "pageTitle": "Tapahtuma-ajat",
     "status": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -690,7 +690,7 @@
     },
     "cancelModal": {
       "title": "Peruuta tapahtuma-aika",
-      "note1": "Oletko varma, että haluat poistaa valitun tapahtuma-ajan?",
+      "note1": "Oletko varma, että haluat peruuttaa valitun tapahtuma-ajan?",
       "note2": "Tähän tapahtuma-aikaan ilmoittautuneiden ilmoittautumiset perutaan ja heille lähetetään peruutusviesti"
     },
     "cancelError": "Tapahtuma-ajan peruminen epäonnistui",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -664,6 +664,10 @@
     "textGroupInfo": "gruppstorlek {{minGroupSize}}–{{maxGroupSize}}",
     "labelLanguages": "Språk"
   },
+  "editOccurrencesPage": {
+    "buttonBackToSummary": "SV: Takaisin tapahtuman tietoihin",
+    "titleEditOccurrences": "SV: Muokkaa tapahtuma-aikoja"
+  },
   "occurrences": {
     "actionsDropdown": {
       "menuItemDelete": "Radera",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -665,8 +665,8 @@
     "labelLanguages": "Språk"
   },
   "editOccurrencesPage": {
-    "buttonBackToSummary": "SV: Takaisin tapahtuman tietoihin",
-    "titleEditOccurrences": "SV: Muokkaa tapahtuma-aikoja"
+    "buttonBackToSummary": "Tillbaka till evenemangsinfo",
+    "titleEditOccurrences": "Ändra datum för evenemang"
   },
   "occurrences": {
     "actionsDropdown": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -683,6 +683,7 @@
     "buttonShowMore": "Visa fler händelser",
     "count": "{{count}} st",
     "deleteError": "Det gick inte att ta bort evenemangtiden",
+    "deleteSuccess": "SV: Tapahtuma-aika poistettu",
     "deleteModal": {
       "buttonDelete": "Bort evenemangtid",
       "text1": "Är du säker på att du vill ta bort evenemangtid?",
@@ -695,7 +696,7 @@
       "note2": "Anmälningar till denna händelse avbryts och ett meddelande skickas till anmälda."
     },
     "cancelError": "Det gick inte att avbryta förekomsten",
-    "cancelErrorSuccess": "Tiden för händelsen avbröts",
+    "cancelSuccess": "Tiden för händelsen avbröts",
     "downloadCalendarError": "Fel vid import",
     "pageTitle": "Evenemangtider",
     "status": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -683,7 +683,7 @@
     "buttonShowMore": "Visa fler händelser",
     "count": "{{count}} st",
     "deleteError": "Det gick inte att ta bort evenemangtiden",
-    "deleteSuccess": "SV: Tapahtuma-aika poistettu",
+    "deleteSuccess": "Datum för evenemang borttaget",
     "deleteModal": {
       "buttonDelete": "Bort evenemangtid",
       "text1": "Är du säker på att du vill ta bort evenemangtid?",

--- a/src/domain/app/routes/LocaleRoutes.tsx
+++ b/src/domain/app/routes/LocaleRoutes.tsx
@@ -18,6 +18,7 @@ import EventsPage from '../../events/EventsPage';
 import MyProfilePage from '../../myProfile/MyProfilePage';
 import NotFoundPage from '../../notFound/NotFoundPage';
 import CreateEventOccurrencePage from '../../occurrence/CreateOccurrencePage';
+import EditOccurrencesPage from '../../occurrence/EditOccurrencesPage';
 import OccurrenceDetailsPage from '../../occurrence/OccurrenceDetailsPage';
 import PageLayout from '../layout/PageLayout';
 import { ROUTES } from './constants';
@@ -86,6 +87,11 @@ const LocaleRoutes: React.FC<
           exact
           path={`/${locale}${ROUTES.EDIT_EVENT}`}
           component={EditEventPage}
+        />
+        <Route
+          exact
+          path={[`/${locale}${ROUTES.EDIT_OCCURRENCES}`]}
+          component={EditOccurrencesPage}
         />
         <Route
           exact

--- a/src/domain/app/routes/constants.ts
+++ b/src/domain/app/routes/constants.ts
@@ -3,6 +3,7 @@ export enum ROUTES {
   CREATE_EVENT = '/events/create',
   COPY_EVENT = '/events/copy/:id',
   CREATE_OCCURRENCE = '/events/:id/occurrences/create',
+  EDIT_OCCURRENCES = '/events/:id/occurrences/edit',
   EDIT_OCCURRENCE = '/events/:id/occurrences/:occurrenceId/edit',
   ENROLMENT_DETAILS = '/events/:id/occurrences/:occurrenceId/enrolments/:enrolmentId',
   EDIT_ENROLMENT = '/events/:eventId/enrolments/:enrolmentId/edit',

--- a/src/domain/event/EventSummaryPage.tsx
+++ b/src/domain/event/EventSummaryPage.tsx
@@ -132,6 +132,10 @@ const EventSummaryPage: React.FC = () => {
     }
   };
 
+  const editOccurrencesButtonLink = isEventDraft
+    ? `/${locale}${ROUTES.CREATE_OCCURRENCE.replace(':id', eventId)}`
+    : `/${locale}${ROUTES.EDIT_OCCURRENCES.replace(':id', eventId)}`;
+
   return (
     <PageWrapper title="occurrences.pageTitle">
       <LoadingSpinner isLoading={loading}>
@@ -183,6 +187,13 @@ const EventSummaryPage: React.FC = () => {
               </div>
 
               <div className={styles.summarySection}>
+                {!isEventDraft && isInternalEnrolment && (
+                  <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <Button onClick={downloadEnrolments} variant="secondary">
+                      {t('eventSummary.buttonExportEnrolments')}
+                    </Button>
+                  </div>
+                )}
                 <div className={styles.sectionTitleRow}>
                   <h2>
                     {t('occurrences.titleOccurrences')}{' '}
@@ -192,20 +203,10 @@ const EventSummaryPage: React.FC = () => {
                       })}
                     </span>
                   </h2>
-                  {!isEventDraft && isInternalEnrolment && (
-                    <Button onClick={downloadEnrolments} variant="secondary">
-                      {t('eventSummary.buttonExportEnrolments')}
-                    </Button>
-                  )}
-                  {isEventDraft && (
-                    <EditButton
-                      text={t('eventSummary.buttonEditOccurrences')}
-                      link={`/${locale}${ROUTES.CREATE_OCCURRENCE.replace(
-                        ':id',
-                        eventId
-                      )}`}
-                    />
-                  )}
+                  <EditButton
+                    text={t('eventSummary.buttonEditOccurrences')}
+                    link={editOccurrencesButtonLink}
+                  />
                 </div>
                 {!!comingOccurrences.length ? (
                   <OccurrencesTableSummary

--- a/src/domain/event/EventSummaryPage.tsx
+++ b/src/domain/event/EventSummaryPage.tsx
@@ -221,7 +221,7 @@ const EventSummaryPage: React.FC = () => {
 
               <div className={styles.summarySection}>
                 {!isEventDraft && isInternalEnrolment && (
-                  <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                  <div className={styles.exportEnrolmentsButtonRow}>
                     <Button onClick={downloadEnrolments} variant="secondary">
                       {t('eventSummary.buttonExportEnrolments')}
                     </Button>

--- a/src/domain/event/EventSummaryPage.tsx
+++ b/src/domain/event/EventSummaryPage.tsx
@@ -14,6 +14,7 @@ import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinne
 import {
   OccurrenceFieldsFragment,
   useCancelOccurrenceMutation,
+  useDeleteOccurrenceMutation,
   useEventQuery,
 } from '../../generated/graphql';
 import useHistory from '../../hooks/useHistory';
@@ -45,6 +46,9 @@ const EventSummaryPage: React.FC = () => {
   const locale = useLocale();
   const lang = i18n.language;
   const [showAllPastEvents, setShowAllPastEvents] = React.useState(false);
+  const [loadingOccurrences, setLoadingOccurrences] = React.useState<string[]>(
+    []
+  );
   const {
     data: eventData,
     loading,
@@ -60,6 +64,7 @@ const EventSummaryPage: React.FC = () => {
     eventData?.event?.pEvent?.id
   );
   const [cancelOccurrence] = useCancelOccurrenceMutation();
+  const [deleteOccurrence] = useDeleteOccurrenceMutation();
 
   const enrolmentType = eventData?.event && getEnrolmentType(eventData.event);
   const organisationId = eventData?.event?.pEvent?.organisation?.id || '';
@@ -83,6 +88,14 @@ const EventSummaryPage: React.FC = () => {
     ':id',
     eventId
   )}`;
+
+  const addLoadingOccurrence = (id: string) => {
+    setLoadingOccurrences((ids) => [...ids, id]);
+  };
+
+  const deleteLoadingOccurrence = (occurrenceId: string) => {
+    setLoadingOccurrences((ids) => ids.filter((id) => id !== occurrenceId));
+  };
 
   const goToEventDetailsPage = () => {
     history.pushWithLocale(`${ROUTES.EVENT_DETAILS.replace(':id', eventId)}`);
@@ -122,13 +135,33 @@ const EventSummaryPage: React.FC = () => {
     message?: string
   ) => {
     try {
+      addLoadingOccurrence(occurrence.id);
       await cancelOccurrence({
         variables: { input: { id: occurrence.id, reason: message } },
       });
       await refetchEventData();
-      toast.success(t('occurrences.cancelErrorSuccess'));
+      deleteLoadingOccurrence(occurrence.id);
+      toast.success(t('occurrences.cancelSuccess'));
     } catch (e) {
+      deleteLoadingOccurrence(occurrence.id);
       toast.error(t('occurrences.cancelError'));
+    }
+  };
+
+  const handleDeleteOccurrence = async (
+    occurrence: OccurrenceFieldsFragment
+  ) => {
+    try {
+      addLoadingOccurrence(occurrence.id);
+      await deleteOccurrence({
+        variables: { input: { id: occurrence.id } },
+      });
+      await refetchEventData();
+      deleteLoadingOccurrence(occurrence.id);
+      toast.success(t('occurrences.deleteSuccess'));
+    } catch (e) {
+      deleteLoadingOccurrence(occurrence.id);
+      toast.error(t('occurrences.deleteError'));
     }
   };
 
@@ -213,6 +246,8 @@ const EventSummaryPage: React.FC = () => {
                     eventData={eventData}
                     occurrences={comingOccurrences}
                     onCancel={handleCancelOccurrence}
+                    onDelete={handleDeleteOccurrence}
+                    loadingOccurrences={loadingOccurrences}
                   />
                 ) : (
                   <div>{t('occurrences.textNoComingOccurrences')}</div>
@@ -228,6 +263,7 @@ const EventSummaryPage: React.FC = () => {
                       </span>
                     </h2>
                     <OccurrencesTableSummary
+                      loadingOccurrences={loadingOccurrences}
                       eventData={eventData}
                       occurrences={
                         showAllPastEvents

--- a/src/domain/event/__tests__/EventSummaryPage.test.tsx
+++ b/src/domain/event/__tests__/EventSummaryPage.test.tsx
@@ -526,7 +526,7 @@ it('can cancel occurrences from occurrence table actions', async () => {
     const dialog = within(await screen.findByRole('dialog'));
     const expectedTextsToBeVisible = [
       'Peruuta tapahtuma-aika',
-      'Oletko varma, että haluat poistaa valitun tapahtuma-ajan?',
+      'Oletko varma, että haluat peruuttaa valitun tapahtuma-ajan?',
       'Tähän tapahtuma-aikaan ilmoittautuneiden ilmoittautumiset perutaan ja heille lähetetään peruutusviesti',
     ];
     expectedTextsToBeVisible.forEach((text) => {

--- a/src/domain/event/__tests__/EventSummaryPage.test.tsx
+++ b/src/domain/event/__tests__/EventSummaryPage.test.tsx
@@ -359,7 +359,7 @@ it('navigates to edit occurrences page when edit occurrences button is clicked',
   );
 });
 
-it('hides edit buttons when event has been published', async () => {
+it('changes edit occurrences button when event has been published', async () => {
   renderWithRoute(<EventSummaryPage />, {
     mocks: getMocks(),
     path: ROUTES.EVENT_SUMMARY,
@@ -377,7 +377,7 @@ it('hides edit buttons when event has been published', async () => {
 
   expect(
     screen.queryByRole('link', { name: 'Muokkaa tapahtuma-aikoja' })
-  ).not.toBeInTheDocument();
+  ).toHaveAttribute('href', '/fi/events/eventMockId2/occurrences/edit');
 
   expect(
     screen.queryByRole('link', {

--- a/src/domain/event/eventSummaryPage.module.scss
+++ b/src/domain/event/eventSummaryPage.module.scss
@@ -69,4 +69,9 @@
       margin: 0;
     }
   }
+
+  .exportEnrolmentsButtonRow {
+    display: flex;
+    justify-content: flex-end;
+  }
 }

--- a/src/domain/occurrence/CreateOccurrencePage.tsx
+++ b/src/domain/occurrence/CreateOccurrencePage.tsx
@@ -1,5 +1,11 @@
 import { useApolloClient } from '@apollo/client';
-import { Form, Formik, FormikContextType, FormikHelpers } from 'formik';
+import {
+  Form,
+  Formik,
+  FormikContextType,
+  FormikHelpers,
+  useFormikContext,
+} from 'formik';
 import { Button } from 'hds-react';
 import compact from 'lodash/compact';
 import omit from 'lodash/omit';
@@ -469,10 +475,11 @@ const OccurrenceInfoForm: React.FC<{
               <FocusToFirstError />
               <LocationFormPart selectedLanguages={selectedLanguages} />
               <EnrolmentInfoFormPart />
-              <OccurrencesFormPart
+              <OccurrencesFormPartWrapper
                 eventData={eventData}
                 createOccurrence={createOccurrence}
                 disabled={loading}
+                title={t('eventForm.occurrences.occurrencesFormSectionTitle')}
               />
               <div className={styles.submitButtons}>
                 <Button
@@ -497,6 +504,33 @@ const OccurrenceInfoForm: React.FC<{
       </Formik>
     </OccurrencesFormHandleContext.Provider>
   );
+};
+
+const OccurrencesFormPartWrapper: React.FC<{
+  eventData: EventQuery;
+  createOccurrence: ReturnType<typeof useAddOccurrenceMutation>[0];
+  disabled: boolean;
+  title: string;
+}> = (props) => {
+  const {
+    values: {
+      location,
+      isVirtual,
+      enrolmentEndDays,
+      enrolmentStart,
+      enrolmentType,
+    },
+  } = useFormikContext<TimeAndLocationFormFields>();
+
+  const formProps = {
+    location,
+    isVirtual,
+    enrolmentEndDays,
+    enrolmentStart,
+    enrolmentType,
+  };
+
+  return <OccurrencesFormPart {...props} {...formProps} />;
 };
 
 export default CreateOccurrencePage;

--- a/src/domain/occurrence/EditOccurrencesPage.tsx
+++ b/src/domain/occurrence/EditOccurrencesPage.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router';
+
+import BackButton from '../../common/components/backButton/BackButton';
+import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
+import { useAddOccurrenceMutation } from '../../generated/graphql';
+import useHistory from '../../hooks/useHistory';
+import useLocale from '../../hooks/useLocale';
+import Container from '../app/layout/Container';
+import PageWrapper from '../app/layout/PageWrapper';
+import { ROUTES } from '../app/routes/constants';
+import ErrorPage from '../errorPage/ErrorPage';
+import { VIRTUAL_EVENT_LOCATION_ID } from '../event/constants';
+import { getEventFields } from '../event/utils';
+import { EnrolmentType } from './constants';
+import styles from './editOccurrencesPage.module.scss';
+import OccurrencesFormPart from './occurrencesFormPart/OccurrencesFormPart';
+import { getEnrolmentType, useBaseEventQuery } from './utils';
+
+interface Params {
+  id: string;
+}
+
+const EditOccurrencesPage: React.FC = () => {
+  const { id: eventId } = useParams<Params>();
+  const history = useHistory();
+  const { t } = useTranslation();
+  const locale = useLocale();
+
+  const { data: eventData, loading: loadingEvent } = useBaseEventQuery({
+    variables: { id: eventId },
+    fetchPolicy: 'network-only',
+  });
+  const event = eventData?.event;
+
+  const [createOccurrence, { loading: addOccurrenceLoading }] =
+    useAddOccurrenceMutation();
+
+  const goToEventSummaryPage = () => {
+    history.pushWithLocale(ROUTES.EVENT_SUMMARY.replace(':id', eventId));
+  };
+
+  const { eventName } = getEventFields(event, locale);
+  const enrolmentType = event ? getEnrolmentType(event) : null;
+  const enrolmentEndDays = event?.pEvent.enrolmentEndDays ?? 0;
+  const enrolmentStart = event?.pEvent.enrolmentStart;
+  const isVirtual = event?.location?.id === VIRTUAL_EVENT_LOCATION_ID;
+  const location = event?.location?.id ?? EnrolmentType.Internal;
+
+  return (
+    <PageWrapper title={t('editOccurrencesPage.titleEditOccurrences')}>
+      <LoadingSpinner isLoading={loadingEvent} hasPadding={false}>
+        <Container>
+          <BackButton onClick={goToEventSummaryPage}>
+            {t('common.back')}
+          </BackButton>
+          {eventData?.event ? (
+            <div className={styles.editOccurrencesPage}>
+              <div className={styles.headerContainer}>
+                <h1>{eventName}</h1>
+              </div>
+              {enrolmentType && (
+                <OccurrencesFormPart
+                  title={t('editOccurrencesPage.titleEditOccurrences')}
+                  createOccurrence={createOccurrence}
+                  eventData={eventData}
+                  enrolmentEndDays={enrolmentEndDays}
+                  enrolmentStart={new Date(enrolmentStart)}
+                  enrolmentType={enrolmentType}
+                  isVirtual={isVirtual}
+                  location={location}
+                  disabled={addOccurrenceLoading}
+                />
+              )}
+            </div>
+          ) : (
+            <ErrorPage />
+          )}
+        </Container>
+      </LoadingSpinner>
+    </PageWrapper>
+  );
+};
+
+export default EditOccurrencesPage;

--- a/src/domain/occurrence/editOccurrencesPage.module.scss
+++ b/src/domain/occurrence/editOccurrencesPage.module.scss
@@ -1,0 +1,3 @@
+.editOccurrencesPage {
+  margin-bottom: var(--spacing-xl);
+}

--- a/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
+++ b/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
@@ -23,10 +23,7 @@ import { getEventFields } from '../../event/utils';
 import { OccurrenceFormContextSetter } from '../../occurrence/OccurrencesFormHandleContext';
 import PlaceText from '../../place/PlaceText';
 import { EnrolmentType } from '../constants';
-import {
-  OccurrenceSectionFormFields,
-  TimeAndLocationFormFields,
-} from '../types';
+import { OccurrenceSectionFormFields } from '../types';
 import {
   getEventQueryVariables,
   getOccurrenceFields,
@@ -59,20 +56,26 @@ const OccurrencesForm: React.FC<{
   eventData: EventQuery;
   createOccurrence: ReturnType<typeof useAddOccurrenceMutation>[0];
   disabled: boolean;
-}> = ({ disabled, eventData, createOccurrence }) => {
+  location: string;
+  isVirtual: boolean;
+  enrolmentStart: Date | null;
+  enrolmentEndDays: number | string;
+  enrolmentType: EnrolmentType;
+  title: string;
+}> = ({
+  disabled,
+  eventData,
+  createOccurrence,
+  enrolmentEndDays,
+  enrolmentStart,
+  enrolmentType,
+  isVirtual,
+  location,
+  title,
+}) => {
   const { t } = useTranslation();
   const locale = useLocale();
   const [deleteOccurrence] = useDeleteOccurrenceMutation();
-
-  const {
-    values: {
-      location,
-      isVirtual,
-      enrolmentEndDays,
-      enrolmentStart,
-      enrolmentType,
-    },
-  } = useFormikContext<TimeAndLocationFormFields>();
 
   const { occurrences, id: eventId } = getEventFields(eventData?.event, locale);
   const pEventId = eventData.event?.pEvent.id as string;
@@ -175,7 +178,7 @@ const OccurrencesForm: React.FC<{
       className={styles.occurrencesFormPart}
       data-testid={occurrencesFormTestId}
     >
-      <h2>{t('eventForm.occurrences.occurrencesFormSectionTitle')}</h2>
+      <h2>{title}</h2>
       {!!occurrences?.length && (
         <OccurrencesTable
           occurrences={occurrences}
@@ -189,7 +192,7 @@ const OccurrencesForm: React.FC<{
         validateOnChange
       >
         <OccurrenceForm
-          eventDefaultlocation={location}
+          eventDefaultlocation={!isVirtual ? location : ''}
           isVirtualEvent={isVirtual}
           enrolmentType={enrolmentType}
           disabled={disabled}

--- a/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
+++ b/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
@@ -20,6 +20,7 @@ import {
 import useLocale from '../../../hooks/useLocale';
 import { formatIntoDateTime } from '../../../utils/time/format';
 import { getEventFields } from '../../event/utils';
+import { PUBLICATION_STATUS } from '../../events/constants';
 import { OccurrenceFormContextSetter } from '../../occurrence/OccurrencesFormHandleContext';
 import PlaceText from '../../place/PlaceText';
 import { EnrolmentType } from '../constants';
@@ -79,6 +80,8 @@ const OccurrencesForm: React.FC<{
 
   const { occurrences, id: eventId } = getEventFields(eventData?.event, locale);
   const pEventId = eventData.event?.pEvent.id as string;
+  const isPublishedEvent =
+    eventData.event?.publicationStatus === PUBLICATION_STATUS.PUBLIC;
 
   const initialValues = React.useMemo(() => {
     return {
@@ -183,6 +186,7 @@ const OccurrencesForm: React.FC<{
         <OccurrencesTable
           occurrences={occurrences}
           onDeleteOccurrence={handleDeleteOccurrence}
+          isPublishedEvent={isPublishedEvent}
         />
       )}
       <Formik
@@ -343,7 +347,8 @@ const OccurrenceForm: React.FC<{
 const OccurrencesTable: React.FC<{
   occurrences: OccurrenceFieldsFragment[];
   onDeleteOccurrence: (id: string) => Promise<void>;
-}> = ({ occurrences, onDeleteOccurrence }) => {
+  isPublishedEvent?: boolean;
+}> = ({ occurrences, onDeleteOccurrence, isPublishedEvent }) => {
   const { t } = useTranslation();
 
   return (
@@ -369,6 +374,8 @@ const OccurrencesTable: React.FC<{
             })
             .join(', ');
 
+          const showDeleteButton = !isPublishedEvent || occurrence.cancelled;
+
           return (
             <tr key={occurrence.id}>
               <td>
@@ -382,13 +389,15 @@ const OccurrencesTable: React.FC<{
               <td>{occurrence.minGroupSize ?? '–'}</td>
               <td>{occurrence.maxGroupSize ?? '–'}</td>
               <td>
-                <button
-                  type="button"
-                  onClick={() => onDeleteOccurrence(occurrence.id)}
-                  aria-label={t('occurrences.table.buttonDeleteOccurrence')}
-                >
-                  <IconMinusCircleFill />
-                </button>
+                {showDeleteButton ? (
+                  <button
+                    type="button"
+                    onClick={() => onDeleteOccurrence(occurrence.id)}
+                    aria-label={t('occurrences.table.buttonDeleteOccurrence')}
+                  >
+                    <IconMinusCircleFill />
+                  </button>
+                ) : null}
               </td>
             </tr>
           );

--- a/src/domain/occurrences/occurrencesTable/ActionsDropdown.tsx
+++ b/src/domain/occurrences/occurrencesTable/ActionsDropdown.tsx
@@ -133,6 +133,7 @@ const ActionsDropdown: React.FC<Props> = ({
   };
 
   const showCancelAction = !row.cancelled && onCancel;
+  const canDelete = isEventDraft || row.cancelled;
 
   const items = [
     enrolmentType === EnrolmentType.Internal && {
@@ -171,7 +172,7 @@ const ActionsDropdown: React.FC<Props> = ({
         </>
       ),
     },
-    isEventDraft && {
+    canDelete && {
       onClick: openDeleteModal,
       children: (
         <>

--- a/src/domain/occurrences/occurrencesTable/__tests__/ActionsDropdown.test.tsx
+++ b/src/domain/occurrences/occurrencesTable/__tests__/ActionsDropdown.test.tsx
@@ -85,7 +85,7 @@ it('renders cancel modal and cancel functionality works', () => {
 
   expect(
     screen.queryByText(
-      'Oletko varma, että haluat poistaa valitun tapahtuma-ajan?'
+      'Oletko varma, että haluat peruuttaa valitun tapahtuma-ajan?'
     )
   ).toBeInTheDocument();
 

--- a/src/domain/occurrences/occurrencesTableReadOnly/OccurrencesTableSummary.tsx
+++ b/src/domain/occurrences/occurrencesTableReadOnly/OccurrencesTableSummary.tsx
@@ -1,3 +1,4 @@
+import { LoadingSpinner } from 'hds-react';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Row } from 'react-table';
@@ -23,12 +24,16 @@ export interface Props {
   eventData?: EventQuery;
   occurrences: OccurrenceFieldsFragment[];
   onCancel?: (occurrence: OccurrenceFieldsFragment, message?: string) => void;
+  onDelete?: (occurrence: OccurrenceFieldsFragment) => void;
+  loadingOccurrences: string[];
 }
 
 const OccurrencesTableSummary: React.FC<Props> = ({
   eventData,
   occurrences,
   onCancel,
+  onDelete,
+  loadingOccurrences,
 }) => {
   const { t } = useTranslation();
   const history = useHistory();
@@ -84,6 +89,9 @@ const OccurrencesTableSummary: React.FC<Props> = ({
         </>
       ),
       accessor: (row: OccurrenceFieldsFragment) => {
+        if (loadingOccurrences.includes(row.id)) {
+          return <LoadingSpinner small />;
+        }
         if (row.cancelled) {
           return (
             <span className={styles.cancelledText}>
@@ -136,6 +144,7 @@ const OccurrencesTableSummary: React.FC<Props> = ({
           event={event}
           eventId={eventId}
           onCancel={onCancel}
+          onDelete={onDelete}
           row={row}
           enrolmentType={enrolmentType}
         />

--- a/src/domain/occurrences/occurrencesTableReadOnly/__tests__/OccurrencesTableSummary.test.tsx
+++ b/src/domain/occurrences/occurrencesTableReadOnly/__tests__/OccurrencesTableSummary.test.tsx
@@ -28,7 +28,11 @@ const mockOccurrence = fakeOccurrence({
 
 const renderComponent = (props?: Partial<Props>) => {
   return render(
-    <OccurrencesTableSummary occurrences={[mockOccurrence]} {...props} />
+    <OccurrencesTableSummary
+      loadingOccurrences={[]}
+      occurrences={[mockOccurrence]}
+      {...props}
+    />
   );
 };
 


### PR DESCRIPTION
## Description :sparkles:

- Add ability to edit occurrences after event has been published
- Add loading indicators to occurrence table when deleting / canceling occurrence

## Issues :bug:
### Closes :no_good_woman:
**[PT-1228](https://helsinkisolutionoffice.atlassian.net/browse/PT-1228):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

<img width="1434" alt="Screenshot 2021-10-31 at 19 42 28" src="https://user-images.githubusercontent.com/15219142/139595558-e65c4718-38ba-4d98-a8f6-fc9c4e80271e.png">

<img width="1252" alt="Screenshot 2021-10-21 at 17 02 59" src="https://user-images.githubusercontent.com/15219142/138294142-75387287-127f-41aa-a86e-d4a3523e5846.png">


## Additional notes :spiral_notepad: