### PR TITLE
PT-1239 | Dont try to fetch language options from cms when not on cms page

### DIFF
--- a/src/domain/app/header/Header.tsx
+++ b/src/domain/app/header/Header.tsx
@@ -173,8 +173,8 @@ const LanguageNavigation: React.FC = () => {
   const locale = i18n.language;
   const { pathname, search } = useLocation();
   const history = useHistory();
-  const languageOptions = useCmsLanguageOptions();
   const isCmsPage = !!useRouteMatch(`/${locale}${ROUTES.CMS_PAGE}`);
+  const languageOptions = useCmsLanguageOptions({ skip: !isCmsPage });
 
   const getCmsHref = (lang: string) => {
     const nav = languageOptions?.find((languageOption) => {

--- a/src/headless-cms/hooks.ts
+++ b/src/headless-cms/hooks.ts
@@ -79,21 +79,27 @@ export const useCmsMenuItems = () => {
   };
 };
 
-export const useCmsLanguageOptions = () => {
+export const useCmsLanguageOptions = ({
+  skip = false,
+}: { skip?: boolean } = {}) => {
   const location = useLocation();
-  const cmsUri = location.pathname.replace(/(\/?(fi|en|sv))?\/?cms-page/, '');
-  const { data: pageData } = usePageQuery(cmsUri);
 
-  return [
-    {
-      uri: pageData?.page?.uri,
-      locale: pageData?.page?.language?.code?.toLowerCase(),
-    },
-    ...(pageData?.page?.translations?.map((translation) => ({
-      uri: translation?.uri,
-      locale: translation?.language?.code?.toLowerCase(),
-    })) ?? []),
-  ];
+  const cmsPageRegexp = /(\/?(fi|en|sv))?\/?cms-page/;
+  const cmsUri = location.pathname.replace(cmsPageRegexp, '');
+  const { data: pageData } = usePageQuery(cmsUri, { skip });
+
+  return !skip
+    ? [
+        {
+          uri: pageData?.page?.uri,
+          locale: pageData?.page?.language?.code?.toLowerCase(),
+        },
+        ...(pageData?.page?.translations?.map((translation) => ({
+          uri: translation?.uri,
+          locale: translation?.language?.code?.toLowerCase(),
+        })) ?? []),
+      ]
+    : [];
 };
 
 export type Breadcrumb = { title: string; uri: string };

--- a/src/headless-cms/usePageQuery.ts
+++ b/src/headless-cms/usePageQuery.ts
@@ -7,13 +7,14 @@ import { normalizeCmsUri } from './utils';
 
 // Takes care of removing surrounding slashes so basically same requests are not repeated
 // instead they are fetched from the cache
-const usePageQuery = (uri: string) => {
+const usePageQuery = (uri: string, { skip }: { skip?: boolean } = {}) => {
   return useOriginalPageQuery({
     client: cmsClient,
     variables: {
       id: normalizeCmsUri(uri),
       idType: PageIdType.Uri,
     },
+    skip: !!skip,
   });
 };
 


### PR DESCRIPTION
## Description :sparkles:

Client was making strange CMS api GraphQL requests when navigatign through pages. `useCmsLanguageOptions` is used to fetch uris for different languages of the current cms page so changing language is possible. This was accidentally done on all pages. To fix this I added skip parameter so `useCmsLanguageOptions` wouldn't do request to CMS api on each page.

## Issues :bug:
### Closes :no_good_woman:
**[PT-1239](https://helsinkisolutionoffice.atlassian.net/browse/PT-1239):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: