### PR TITLE
PT-1274 | Show dash instead of 0 when amounOfSeats if 0

### DIFF
--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -773,7 +773,7 @@ describe('occurrences form', () => {
       ],
     });
 
-    const occurrence1RowText = `Sellon kirjasto10.5.2021 10:0010.5.2021 11:00englanti, suomi0––`;
+    const occurrence1RowText = `Sellon kirjasto10.5.2021 10:0010.5.2021 11:00englanti, suomi–––`;
 
     // Wait for form to have been initialized
     await screen.findByTestId('time-and-location-form');

--- a/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
+++ b/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
@@ -374,7 +374,8 @@ const OccurrencesTable: React.FC<{
               <td>{formatIntoDateTime(new Date(occurrence.startTime))}</td>
               <td>{formatIntoDateTime(new Date(occurrence.endTime))}</td>
               <td>{formattedLanguages}</td>
-              <td>{occurrence.amountOfSeats}</td>
+              {/* Using '||' because we want to show '-' if amount of seats not defined or is 0 */}
+              <td>{occurrence.amountOfSeats || '–'}</td>
               <td>{occurrence.minGroupSize ?? '–'}</td>
               <td>{occurrence.maxGroupSize ?? '–'}</td>
               <td>


### PR DESCRIPTION
## Description :sparkles:

After adding more enrolment types there has been problem with the occurrences tables seats column in create occurrence page (second step of event creation). For example with external enrolment amount of seats is not given to the occurrence but API requires it as an integer. We have been using 0 for that parameter and it has caused 0 to be shown in the table. This PR fixes the UI problem by not displaying falsy values in seats column.

## Issues :bug:
### Closes :no_good_woman:
**[PT-1274](https://helsinkisolutionoffice.atlassian.net/browse/PT-1274):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

<img width="1213" alt="Screenshot 2021-10-26 at 12 13 08" src="https://user-images.githubusercontent.com/15219142/138848437-f4c74a67-7cda-4d43-989f-52ef238414db.png">


## Additional notes :spiral_notepad: