### PR TITLE
feat: unit place selector uses schoolsAndKindergartens query

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -101,7 +101,10 @@
     "linkSkipToContent": "Skip to content",
     "openInNewTab": "(opens in a new tab)",
     "notification": "Notification",
-    "getStaffRightsInstructionsText": "Please fill out this <a href=\"{{url}}\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"{{openInNewTab}}\">form</a> in order to manage events!"
+    "getStaffRightsInstructionsText": "Please fill out this <a href=\"{{url}}\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"{{openInNewTab}}\">form</a> in order to manage events!",
+    "unitPlaceSelector": {
+      "noPlaceFoundError": "Unit is selected, but there was a problem loading the name"
+    }
   },
   "cms": {
     "linkFrontPage": "Home page",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -101,7 +101,10 @@
     "linkSkipToContent": "Siirry sisältöön",
     "openInNewTab": "(avataan uudessa välilehdessä)",
     "notification": "Ilmoitus",
-    "getStaffRightsInstructionsText": "Hanki oikeus tapahtumien julkaisuun tällä <a href=\"{{url}}\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"lomakkeella {{openInNewTab}}\">lomakkeella</a>"
+    "getStaffRightsInstructionsText": "Hanki oikeus tapahtumien julkaisuun tällä <a href=\"{{url}}\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"lomakkeella {{openInNewTab}}\">lomakkeella</a>",
+    "unitPlaceSelector": {
+      "noPlaceFoundError": "Paikka on valittu, mutta nimen latauksessa esiintyi ongelma"
+    }
   },
   "cms": {
     "linkFrontPage": "Kotisivu",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -100,7 +100,10 @@
     "linkSkipToContent": "Gå till innehållet",
     "openInNewTab": "(öppnas i en ny flik)",
     "notification": "Underrättelse",
-    "getStaffRightsInstructionsText": "Skaffa rättighet att publicera evenemang med denna <a href=\"{{url}}\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"{{openInNewTab}}\">form</a> blankett!"
+    "getStaffRightsInstructionsText": "Skaffa rättighet att publicera evenemang med denna <a href=\"{{url}}\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"{{openInNewTab}}\">form</a> blankett!",
+    "unitPlaceSelector": {
+      "noPlaceFoundError": "Platsen har valts, men det gick inte att läsa in namnet"
+    }
   },
   "cms": {
     "linkFrontPage": "Hemsidan",

--- a/src/domain/enrolment/__tests__/EditEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/EditEnrolmentPage.test.tsx
@@ -1,11 +1,16 @@
 /* eslint-disable import/no-duplicates */
+import { MockedResponse } from '@apollo/client/testing';
 import cloneDeep from 'lodash/cloneDeep';
 import * as React from 'react';
+import wait from 'waait';
 
 import { EnrolmentDocument } from '../../../generated/graphql';
 import * as graphqlFns from '../../../generated/graphql';
+import { createPlaceQueryMock } from '../../../test/apollo-mocks/placeMocks';
+import { createSchoolsAndKindergartensListQueryMock } from '../../../test/apollo-mocks/schoolsAndKindergartensListMock';
 import {
   fakeEnrolment,
+  fakeLocalizedObject,
   fakeOccurrence,
   fakeOrganisation,
   fakePerson,
@@ -14,6 +19,7 @@ import {
   fakeStudyLevels,
 } from '../../../utils/mockDataUtils';
 import {
+  act,
   renderWithRoute,
   screen,
   userEvent,
@@ -283,4 +289,257 @@ it('calls update enrolment function with correct parameters when form is submitt
       search: 'enrolmentUpdated=true',
     },
   ]);
+});
+
+describe('UnitField', () => {
+  const setupUnitFieldTest = async (testMocks: MockedResponse[] = []) => {
+    const enrolmentWithoutUnit = {
+      ...enrolment,
+      studyGroup: {
+        ...enrolment.studyGroup,
+        unitName: '',
+      },
+    };
+
+    const apolloMocks = [
+      ...testMocks,
+      {
+        request: {
+          query: EnrolmentDocument,
+          variables: {
+            id: 'RW5yb2xtZW50Tm9kZToyNw==',
+          },
+        },
+        result: {
+          data: { enrolment: enrolmentWithoutUnit },
+        },
+      },
+      createSchoolsAndKindergartensListQueryMock(10, [
+        { id: 'test:place1', name: fakeLocalizedObject('place1') },
+        { id: 'test:place2', name: fakeLocalizedObject('place2') },
+        { id: 'test:place12', name: fakeLocalizedObject('place12') },
+        { id: 'test:place123', name: fakeLocalizedObject('place123') },
+      ]),
+    ];
+
+    renderPage({ mocks: apolloMocks });
+
+    await screen.findByRole('heading', {
+      name: messages.enrolment.editEnrolmentTitle,
+    });
+  };
+
+  it('renders properly', async () => {
+    await setupUnitFieldTest();
+
+    // First it renders the autosuggest field
+    expect(
+      screen.getByRole('textbox', {
+        name: /päiväkoti \/ koulu \/ oppilaitos/i,
+      })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/etsi helsinkiläistä toimipistettä/i)
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(/kirjoita toimipaikan nimi/i)
+    ).not.toBeInTheDocument();
+
+    // When checkbox is checked
+    act(() => {
+      userEvent.click(
+        screen.getByRole('checkbox', {
+          name: /paikka ei ole listalla/i,
+        })
+      );
+    });
+
+    // It renders the freetext input field
+    expect(
+      screen.queryByText(/etsi helsinkiläistä toimipistettä/i)
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByText(/kirjoita toimipaikan nimi/i)).toBeInTheDocument();
+
+    userEvent.type(
+      screen.getByRole('textbox', {
+        name: /päiväkoti \/ koulu \/ oppilaitos/i,
+      }),
+      'Testikoulu'
+    );
+
+    userEvent.tab();
+
+    expect(
+      screen.getByRole('textbox', {
+        name: /päiväkoti \/ koulu \/ oppilaitos/i,
+      })
+    ).toHaveValue('Testikoulu');
+  });
+
+  it('renders a list of schools and kindergartens in unit id field', async () => {
+    await setupUnitFieldTest();
+
+    // Type to unit id field
+    userEvent.type(
+      screen.getByRole('textbox', {
+        name: /päiväkoti \/ koulu \/ oppilaitos/i,
+      }),
+      'place'
+    );
+
+    // wait for debounce to trigger and populate localStorage
+    await act(() => wait(500));
+
+    // The inserted text should filter autosuggest field options
+    expect(screen.getByText('place12')).toBeInTheDocument();
+    expect(screen.getByText('place123')).toBeInTheDocument();
+    expect(screen.queryByText('place1')).toBeInTheDocument();
+    expect(screen.queryByText('place2')).toBeInTheDocument();
+
+    // Type to unit id field
+    userEvent.clear(
+      screen.getByRole('textbox', {
+        name: /päiväkoti \/ koulu \/ oppilaitos/i,
+      })
+    );
+    userEvent.type(
+      screen.getByRole('textbox', {
+        name: /päiväkoti \/ koulu \/ oppilaitos/i,
+      }),
+      'place12'
+    );
+
+    // wait for debounce to trigger and populate localStorage
+    await act(() => wait(500));
+
+    // The inserted text should filter autosuggest field options
+    expect(screen.getByText('place12')).toBeInTheDocument();
+    expect(screen.getByText('place123')).toBeInTheDocument();
+    expect(screen.queryByText('place1')).not.toBeInTheDocument();
+    expect(screen.queryByText('place2')).not.toBeInTheDocument();
+  });
+
+  it('renders prefilled unit id', async () => {
+    const enrolmentWithoutUnit = {
+      ...enrolment,
+      studyGroup: {
+        ...enrolment.studyGroup,
+        unitId: 'test:place12',
+        unitName: 'place12',
+      },
+    };
+
+    const apolloMocks = [
+      createPlaceQueryMock({
+        id: 'test:place12',
+        name: fakeLocalizedObject('place12'),
+      }),
+      {
+        request: {
+          query: EnrolmentDocument,
+          variables: {
+            id: 'RW5yb2xtZW50Tm9kZToyNw==',
+          },
+        },
+        result: {
+          data: { enrolment: enrolmentWithoutUnit },
+        },
+      },
+      createSchoolsAndKindergartensListQueryMock(10, [
+        { id: 'test:place1', name: fakeLocalizedObject('place1') },
+        { id: 'test:place2', name: fakeLocalizedObject('place2') },
+        { id: 'test:place12', name: fakeLocalizedObject('place12') },
+        { id: 'test:place123', name: fakeLocalizedObject('place123') },
+      ]),
+    ];
+
+    renderPage({ mocks: apolloMocks });
+
+    await screen.findByRole('heading', {
+      name: messages.enrolment.editEnrolmentTitle,
+    });
+
+    expect(screen.getByText(/place12/i)).toBeInTheDocument();
+  });
+
+  it.each<MockedResponse[] | undefined>([
+    [
+      createPlaceQueryMock({
+        id: 'test:place12',
+        name: fakeLocalizedObject('place12'),
+      }),
+    ],
+    undefined,
+  ])(
+    'shows the unit text in a autosuggest div next to the input (%p)',
+    async (placeMocks) => {
+      await setupUnitFieldTest(placeMocks);
+
+      userEvent.type(
+        screen.getByRole('textbox', {
+          name: /päiväkoti \/ koulu \/ oppilaitos/i,
+        }),
+        'place12'
+      );
+
+      // wait for debounce to trigger and populate localStorage
+      await act(() => wait(500));
+
+      expect(screen.getByText('place12')).toBeInTheDocument();
+
+      // Select an unit
+      userEvent.click(screen.getByText('place12'));
+
+      await act(() => wait(500));
+
+      expect(
+        screen.getByRole('textbox', {
+          name: /päiväkoti \/ koulu \/ oppilaitos/i,
+        }).nextElementSibling
+      ).toHaveTextContent(
+        placeMocks ? 'place12' : 'unitPlaceSelector.noPlaceFoundError'
+      );
+    }
+  );
+
+  it('clears the unit id value when a clear button is clicked', async () => {
+    await setupUnitFieldTest();
+
+    userEvent.type(
+      screen.getByRole('textbox', {
+        name: /päiväkoti \/ koulu \/ oppilaitos/i,
+      }),
+      'place12'
+    );
+
+    // wait for debounce to trigger and populate localStorage
+    await act(() => wait(500));
+
+    expect(screen.getByText('place12')).toBeInTheDocument();
+
+    // Select an unit
+    userEvent.click(screen.getByText('place12'));
+
+    expect(
+      screen.getByRole('textbox', {
+        name: /päiväkoti \/ koulu \/ oppilaitos/i,
+      }).nextElementSibling
+    ).not.toBe(null);
+
+    // clear the selection
+    userEvent.click(
+      screen.getByRole('button', {
+        name: /poista arvo/i,
+      })
+    );
+    // No sibling anymore when the value is cleared
+    expect(
+      screen.getByRole('textbox', {
+        name: /päiväkoti \/ koulu \/ oppilaitos/i,
+      }).nextElementSibling
+    ).toBe(null);
+  });
 });

--- a/src/domain/event/eventPreviewCard/__tests__/__snapshots__/EventPreviewCard.test.tsx.snap
+++ b/src/domain/event/eventPreviewCard/__tests__/__snapshots__/EventPreviewCard.test.tsx.snap
@@ -73,7 +73,6 @@ exports[`renders event information correctly and matches snapshot 1`] = `
               />
             </g>
           </svg>
-          
         </div>
       </div>
       <div

--- a/src/domain/place/placeText/PlaceText.tsx
+++ b/src/domain/place/placeText/PlaceText.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import { usePlaceQuery } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
@@ -12,12 +11,12 @@ interface Props {
 
 const PlaceText: React.FC<Props> = ({ placeId, errorText = '' }) => {
   const locale = useLocale();
-  const { t } = useTranslation();
-  const { data } = usePlaceQuery({
+  const { data, loading } = usePlaceQuery({
     variables: { id: placeId },
   });
   const text = getLocalisedString(data?.place?.name || {}, locale);
-  return <>{text || errorText}</>;
+
+  return !loading ? <>{text || errorText}</> : null;
 };
 
 export default PlaceText;

--- a/src/domain/place/placeText/PlaceText.tsx
+++ b/src/domain/place/placeText/PlaceText.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { usePlaceQuery } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
@@ -6,15 +7,17 @@ import getLocalisedString from '../../../utils/getLocalizedString';
 
 interface Props {
   placeId: string;
+  errorText?: string;
 }
 
-const PlaceText: React.FC<Props> = ({ placeId }) => {
+const PlaceText: React.FC<Props> = ({ placeId, errorText = '' }) => {
   const locale = useLocale();
+  const { t } = useTranslation();
   const { data } = usePlaceQuery({
     variables: { id: placeId },
   });
-
-  return <>{getLocalisedString(data?.place?.name || {}, locale)}</>;
+  const text = getLocalisedString(data?.place?.name || {}, locale);
+  return <>{text || errorText}</>;
 };
 
 export default PlaceText;

--- a/src/domain/place/query.ts
+++ b/src/domain/place/query.ts
@@ -51,4 +51,19 @@ export const QUERY_PLACE = gql`
       }
     }
   }
+  query SchoolsAndKindergartensList {
+    schoolsAndKindergartensList {
+      meta {
+        count
+      }
+      data {
+        id
+        name {
+          fi
+          sv
+          en
+        }
+      }
+    }
+  }
 `;

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -67,7 +67,11 @@ export type AddEventMutationInput = {
   audienceMinAge?: Maybe<Scalars['String']>;
   audienceMaxAge?: Maybe<Scalars['String']>;
   superEventType?: Maybe<Scalars['String']>;
-  extensionCourse?: Maybe<IdObjectInput>;
+  enrolmentStartTime?: Maybe<Scalars['String']>;
+  enrolmentEndTime?: Maybe<Scalars['String']>;
+  maximumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  minimumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  remainingAttendeeCapacity?: Maybe<Scalars['Int']>;
   name: LocalisedObjectInput;
   localizationExtraInfo?: Maybe<LocalisedObjectInput>;
   shortDescription: LocalisedObjectInput;
@@ -360,7 +364,11 @@ export type Event = {
   audienceMinAge?: Maybe<Scalars['String']>;
   audienceMaxAge?: Maybe<Scalars['String']>;
   superEventType?: Maybe<Scalars['String']>;
-  extensionCourse?: Maybe<ExtensionCourse>;
+  enrolmentStartTime?: Maybe<Scalars['String']>;
+  enrolmentEndTime?: Maybe<Scalars['String']>;
+  maximumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  minimumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  remainingAttendeeCapacity?: Maybe<Scalars['Int']>;
   name: LocalisedObject;
   localizationExtraInfo?: Maybe<LocalisedObject>;
   shortDescription: LocalisedObject;
@@ -396,15 +404,6 @@ export type EventSearchListResponse = {
   __typename?: 'EventSearchListResponse';
   meta: Meta;
   data: Array<Event>;
-};
-
-export type ExtensionCourse = {
-  __typename?: 'ExtensionCourse';
-  enrolmentStartTime?: Maybe<Scalars['String']>;
-  enrolmentEndTime?: Maybe<Scalars['String']>;
-  maximumAttendeeCapacity?: Maybe<Scalars['Int']>;
-  minimumAttendeeCapacity?: Maybe<Scalars['Int']>;
-  remainingAttendeeCapacity?: Maybe<Scalars['Int']>;
 };
 
 export type ExternalLink = {
@@ -1303,7 +1302,11 @@ export type PublishEventMutationInput = {
   audienceMinAge?: Maybe<Scalars['String']>;
   audienceMaxAge?: Maybe<Scalars['String']>;
   superEventType?: Maybe<Scalars['String']>;
-  extensionCourse?: Maybe<IdObjectInput>;
+  enrolmentStartTime?: Maybe<Scalars['String']>;
+  enrolmentEndTime?: Maybe<Scalars['String']>;
+  maximumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  minimumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  remainingAttendeeCapacity?: Maybe<Scalars['Int']>;
   name: LocalisedObjectInput;
   localizationExtraInfo?: Maybe<LocalisedObjectInput>;
   shortDescription: LocalisedObjectInput;
@@ -1354,6 +1357,8 @@ export type Query = {
   image?: Maybe<Image>;
   keywords?: Maybe<KeywordListResponse>;
   keyword?: Maybe<Keyword>;
+  /** Keywords related to Kultus ordered by the number of events */
+  popularKultusKeywords?: Maybe<KeywordListResponse>;
   keywordSet?: Maybe<KeywordSet>;
   eventsSearch?: Maybe<EventSearchListResponse>;
   placesSearch?: Maybe<PlaceSearchListResponse>;
@@ -1496,12 +1501,6 @@ export type QueryOrganisationsArgs = {
 };
 
 
-export type QuerySchoolsAndKindergartensListArgs = {
-  page?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
-};
-
-
 export type QueryEventsArgs = {
   division?: Maybe<Array<Maybe<Scalars['String']>>>;
   end?: Maybe<Scalars['String']>;
@@ -1569,6 +1568,12 @@ export type QueryKeywordsArgs = {
 
 export type QueryKeywordArgs = {
   id: Scalars['ID'];
+};
+
+
+export type QueryPopularKultusKeywordsArgs = {
+  amount?: Maybe<Scalars['Int']>;
+  showAllKeywords?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -1789,7 +1794,11 @@ export type UpdateEventMutationInput = {
   audienceMinAge?: Maybe<Scalars['String']>;
   audienceMaxAge?: Maybe<Scalars['String']>;
   superEventType?: Maybe<Scalars['String']>;
-  extensionCourse?: Maybe<IdObjectInput>;
+  enrolmentStartTime?: Maybe<Scalars['String']>;
+  enrolmentEndTime?: Maybe<Scalars['String']>;
+  maximumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  minimumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  remainingAttendeeCapacity?: Maybe<Scalars['Int']>;
   name: LocalisedObjectInput;
   localizationExtraInfo?: Maybe<LocalisedObjectInput>;
   shortDescription: LocalisedObjectInput;
@@ -2301,6 +2310,11 @@ export type PlacesQueryVariables = Exact<{
 
 
 export type PlacesQuery = { __typename?: 'Query', places?: Maybe<{ __typename?: 'PlaceListResponse', meta: { __typename?: 'Meta', count?: Maybe<number>, next?: Maybe<string>, previous?: Maybe<string> }, data: Array<{ __typename?: 'Place', id?: Maybe<string>, internalId: string, name?: Maybe<{ __typename?: 'LocalisedObject', en?: Maybe<string>, fi?: Maybe<string>, sv?: Maybe<string> }>, streetAddress?: Maybe<{ __typename?: 'LocalisedObject', en?: Maybe<string>, fi?: Maybe<string>, sv?: Maybe<string> }>, addressLocality?: Maybe<{ __typename?: 'LocalisedObject', en?: Maybe<string>, fi?: Maybe<string>, sv?: Maybe<string> }>, telephone?: Maybe<{ __typename?: 'LocalisedObject', en?: Maybe<string>, fi?: Maybe<string>, sv?: Maybe<string> }> }> }> };
+
+export type SchoolsAndKindergartensListQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type SchoolsAndKindergartensListQuery = { __typename?: 'Query', schoolsAndKindergartensList?: Maybe<{ __typename?: 'ServiceUnitNameListResponse', meta: { __typename?: 'Meta', count?: Maybe<number> }, data: Array<{ __typename?: 'ServiceUnitNode', id: string, name?: Maybe<{ __typename?: 'LocalisedObject', fi?: Maybe<string>, sv?: Maybe<string>, en?: Maybe<string> }> }> }> };
 
 export type StudyLevelFieldsFragment = { __typename?: 'StudyLevelNode', id: string, label?: Maybe<string>, level: number, translations: Array<{ __typename?: 'StudyLevelTranslationType', languageCode: Language, label: string }> };
 
@@ -4183,6 +4197,50 @@ export function usePlacesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Pla
 export type PlacesQueryHookResult = ReturnType<typeof usePlacesQuery>;
 export type PlacesLazyQueryHookResult = ReturnType<typeof usePlacesLazyQuery>;
 export type PlacesQueryResult = Apollo.QueryResult<PlacesQuery, PlacesQueryVariables>;
+export const SchoolsAndKindergartensListDocument = gql`
+    query SchoolsAndKindergartensList {
+  schoolsAndKindergartensList {
+    meta {
+      count
+    }
+    data {
+      id
+      name {
+        fi
+        sv
+        en
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useSchoolsAndKindergartensListQuery__
+ *
+ * To run a query within a React component, call `useSchoolsAndKindergartensListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSchoolsAndKindergartensListQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSchoolsAndKindergartensListQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useSchoolsAndKindergartensListQuery(baseOptions?: Apollo.QueryHookOptions<SchoolsAndKindergartensListQuery, SchoolsAndKindergartensListQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SchoolsAndKindergartensListQuery, SchoolsAndKindergartensListQueryVariables>(SchoolsAndKindergartensListDocument, options);
+      }
+export function useSchoolsAndKindergartensListLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SchoolsAndKindergartensListQuery, SchoolsAndKindergartensListQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SchoolsAndKindergartensListQuery, SchoolsAndKindergartensListQueryVariables>(SchoolsAndKindergartensListDocument, options);
+        }
+export type SchoolsAndKindergartensListQueryHookResult = ReturnType<typeof useSchoolsAndKindergartensListQuery>;
+export type SchoolsAndKindergartensListLazyQueryHookResult = ReturnType<typeof useSchoolsAndKindergartensListLazyQuery>;
+export type SchoolsAndKindergartensListQueryResult = Apollo.QueryResult<SchoolsAndKindergartensListQuery, SchoolsAndKindergartensListQueryVariables>;
 export const StudyLevelsDocument = gql`
     query StudyLevels {
   studyLevels {

--- a/src/test/apollo-mocks/placeMocks.ts
+++ b/src/test/apollo-mocks/placeMocks.ts
@@ -1,0 +1,20 @@
+import { MockedResponse } from '@apollo/client/testing';
+
+import { Place, PlaceDocument } from '../../generated/graphql';
+import { fakePlace } from '../../utils/mockDataUtils';
+
+export const createPlaceQueryMock = (
+  overrides: Partial<Place> & { id: Place['id'] }
+): MockedResponse => ({
+  request: {
+    query: PlaceDocument,
+    variables: {
+      id: overrides.id,
+    },
+  },
+  result: {
+    data: {
+      place: fakePlace(overrides),
+    },
+  },
+});

--- a/src/test/apollo-mocks/schoolsAndKindergartensListMock.ts
+++ b/src/test/apollo-mocks/schoolsAndKindergartensListMock.ts
@@ -1,0 +1,22 @@
+import { MockedResponse } from '@apollo/client/testing';
+
+import {
+  Place,
+  SchoolsAndKindergartensListDocument,
+} from '../../generated/graphql';
+import { fakePlaces } from '../../utils/mockDataUtils';
+
+export const createSchoolsAndKindergartensListQueryMock = (
+  count = 1,
+  places?: Partial<Place>[]
+): MockedResponse => ({
+  request: {
+    query: SchoolsAndKindergartensListDocument,
+    variables: {},
+  },
+  result: {
+    data: {
+      schoolsAndKindergartensList: fakePlaces(count, places),
+    },
+  },
+});


### PR DESCRIPTION
API returns all the units (1000+ pcs) all at once from schoolsAndKindergartens graphql query. The Enrolment form autosuggest field for unit selection should be able to filter the list of units with an input value.

PT-1298 PT-1313.

Same ticket in palvelutarjotin-ui: https://github.com/City-of-Helsinki/palvelutarjotin-ui/pull/173

----

The list of schools and kindergartens is from Servicemap API, but the selected place is queried from LinkedEvents places-API


![image](https://user-images.githubusercontent.com/389204/141289055-87e355d1-fa1b-49c9-9547-75a5f28e6609.png)


with error:

![image](https://user-images.githubusercontent.com/389204/141289647-7cfb06c3-c53c-4f39-84af-634e1fd5d091.png)
