### PR TITLE
fix: unit id fields entries are filtered in lowercase format

### DIFF
--- a/src/domain/place/UnitPlaceSelector.tsx
+++ b/src/domain/place/UnitPlaceSelector.tsx
@@ -76,7 +76,9 @@ const UnitPlaceSelector: React.FC<Props> = ({
         value: place.id || '',
       }))
       // Filter the results with a search value!
-      .filter((place) => place.label.includes(searchValue)) || [];
+      .filter((place) =>
+        place.label.toLowerCase().includes(searchValue.toLowerCase())
+      ) || [];
 
   const handleBlur = (
     option: AutoSuggestOption | AutoSuggestOption[] | null


### PR DESCRIPTION
PT-1357 PT-1343

Same ting done in palvelutarjotin-ui: https://github.com/City-of-Helsinki/palvelutarjotin-ui/pull/182