### PR TITLE
PT-1321 | Update enrolment link label to also have email

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -414,7 +414,7 @@
     },
     "enrolment": {
       "title": "Enrolment",
-      "labelExternalEnrolmentUrl": "Web address for the registration form"
+      "labelExternalEnrolmentUrlOrEmail": "Email or web address for enrolment"
     },
     "enrolmentType": {
       "labelInternal": "Internal enrolments at Kultus",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -420,7 +420,7 @@
     },
     "enrolment": {
       "title": "Ilmoittautuminen",
-      "labelExternalEnrolmentUrl": "WWW-osoite ilmoittautumislomakkeelle"
+      "labelExternalEnrolmentUrlOrEmail": "Sähköposti- tai www-osoite ilmoittautumiseen"
     },
     "enrolmentType": {
       "labelInternal": "Ilmoittautuminen Kultuksessa",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -421,7 +421,7 @@
     },
     "enrolment": {
       "title": "Inskrivning",
-      "labelExternalEnrolmentUrl": "Webbadress för registreringsformuläret"
+      "labelExternalEnrolmentUrlOrEmail": "E-post- eller nätadress för anmälningar"
     },
     "enrolmentType": {
       "labelInternal": "Interna registreringar på Kultus",

--- a/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
+++ b/src/domain/occurrence/__tests__/CreateOccurrencePage.test.tsx
@@ -1149,7 +1149,7 @@ describe('enrolment type selector', () => {
       /tarvittavat käyntikerrat/i,
       /vahvista ilmoittautumiset automaattisesti osallistujamäärän puitteissa/i,
     ],
-    [EnrolmentType.External]: [/www-osoite ilmoittautumislomakkeelle/i],
+    [EnrolmentType.External]: [/Sähköposti- tai www-osoite ilmoittautumiseen/i],
     [EnrolmentType.Unenrollable]: [] as RegExp[],
   };
 
@@ -1353,7 +1353,7 @@ const getFormElement = (
       });
     case 'enrolmentUrl':
       return screen.getByRole('textbox', {
-        name: /www-osoite ilmoittautumislomakkeelle/i,
+        name: /Sähköposti- tai www-osoite ilmoittautumiseen/i,
       });
   }
 };

--- a/src/domain/occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart.tsx
+++ b/src/domain/occurrence/enrolmentInfoFormPart/EnrolmentInfoFormPart.tsx
@@ -139,7 +139,7 @@ export const ExternalEnrolmentFields: React.FC = () => {
     <div>
       <div>
         <Field
-          label={t('eventForm.enrolment.labelExternalEnrolmentUrl')}
+          label={t('eventForm.enrolment.labelExternalEnrolmentUrlOrEmail')}
           name="externalEnrolmentUrl"
           component={TextInputField}
         />


### PR DESCRIPTION
## Description :sparkles:

- Update enrolment link label to also have email

## Issues :bug:
### Closes :no_good_woman:
**[PT-1321](https://helsinkisolutionoffice.atlassian.net/browse/PT-1321):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: