### PR TITLE
PT-1415 | Fix occurrences listing in event summary showing ongoing occurrences in the past section

### DIFF
--- a/src/domain/event/EventSummaryPage.tsx
+++ b/src/domain/event/EventSummaryPage.tsx
@@ -78,10 +78,10 @@ const EventSummaryPage: React.FC = () => {
     ) as OccurrenceFieldsFragment[]) || [];
 
   const comingOccurrences = occurrences.filter(
-    (item) => !isPast(new Date(item.startTime))
+    (item) => !isPast(new Date(item.endTime))
   );
   const pastOccurrences = occurrences.filter((item) =>
-    isPast(new Date(item.startTime))
+    isPast(new Date(item.endTime))
   );
 
   const eventPreviewLink = `/${lang}${ROUTES.EVENT_PREVIEW.replace(

--- a/src/domain/event/__tests__/EventSummaryPage.test.tsx
+++ b/src/domain/event/__tests__/EventSummaryPage.test.tsx
@@ -128,8 +128,13 @@ const eventMock2 = getFakeEvent(
     publicationStatus: PUBLICATION_STATUS.PUBLIC,
   },
   {
-    occurrences: fakeOccurrences(3, [
+    occurrences: fakeOccurrences(4, [
       { startTime: new Date(2020, 11, 11).toISOString() },
+      // occurrence with startTime in the past but endTime in the future
+      {
+        startTime: new Date(2020, 9, 13).toISOString(),
+        endTime: new Date(2020, 11, 11).toISOString(),
+      },
       { startTime: new Date(2020, 9, 12).toISOString() },
       { startTime: new Date(2020, 8, 13).toISOString() },
     ]),
@@ -421,7 +426,7 @@ it('shows upcoming and past occurrences', async () => {
   });
 
   expect(
-    screen.getByRole('heading', { name: 'Tapahtuma-ajat 1 kpl' })
+    screen.getByRole('heading', { name: 'Tapahtuma-ajat 2 kpl' })
   ).toBeInTheDocument();
 
   expect(


### PR DESCRIPTION
## Description :sparkles:

- Fix occurrences listing in event summary showing ongoing events in the past section

## Issues :bug:
### Closes :no_good_woman:
**[PT-1415](https://helsinkisolutionoffice.atlassian.net/browse/PT-1415):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

- Add 1 more occurrence to test data that has start time in the past and end time in the future and update test related to that.

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: