### PR TITLE
Add img and figure styles to fix cms page with big image

### DIFF
--- a/src/headless-cms/components/cmsPage.module.scss
+++ b/src/headless-cms/components/cmsPage.module.scss
@@ -55,6 +55,14 @@
   display: flex;
   flex-direction: column;
 
+  img {
+    width: 100%;
+  }
+
+  figure {
+    margin: 0;
+  }
+
   @include respond-above(sm) {
     flex-direction: row;
   }


### PR DESCRIPTION
## Description :sparkles:

Image from CMS was rendered too big (pushed sidebar too small) and was not aligned very well.

## Issues :bug:
### Closes :no_good_woman:
**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

<img width="1459" alt="Screenshot 2022-02-02 at 15 38 15" src="https://user-images.githubusercontent.com/15219142/152164565-8481fe03-dcd3-4146-b3fa-a2e5ab836be6.png">


## Additional notes :spiral_notepad: