### PR TITLE
chore: normalize price field value

### DIFF
--- a/src/domain/event/__tests__/CreateEventPage.test.tsx
+++ b/src/domain/event/__tests__/CreateEventPage.test.tsx
@@ -337,14 +337,46 @@ describe('Event price section', () => {
     expect(screen.getByLabelText(/Hinta/)).toBeDisabled();
     expect(screen.getByLabelText(/Lisätiedot/)).toBeDisabled();
 
-    userEvent.click(screen.getByLabelText(/Tapahtuma on ilmainen/));
-
+    act(() => {
+      userEvent.click(screen.getByLabelText(/Tapahtuma on ilmainen/));
+    });
     expect(screen.getByLabelText(/Tapahtuma on ilmainen/)).not.toBeChecked();
     expect(screen.getByLabelText(/Hinta/)).not.toBeDisabled();
     expect(screen.getByLabelText(/Lisätiedot/)).not.toBeDisabled();
 
     // to avoid "An update to Formik inside a test was not wrapped in act(...).""
     await screen.findByLabelText(/Tapahtuma on ilmainen/);
+  });
+
+  test('free text cannot be added to the price field', async () => {
+    render(<CreateEventPage />, { mocks });
+    await screen.findByLabelText(/Tapahtuma on ilmainen/);
+    act(() => {
+      userEvent.click(screen.getByLabelText(/Tapahtuma on ilmainen/));
+    });
+    userEvent.type(screen.getByLabelText(/Hinta/), '15 euroa');
+    userEvent.tab();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/tämän kentän on oltava kelvollinen numero/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('commas are converted to dots', async () => {
+    render(<CreateEventPage />, { mocks });
+    await screen.findByLabelText(/Tapahtuma on ilmainen/);
+    act(() => {
+      userEvent.click(screen.getByLabelText(/Tapahtuma on ilmainen/));
+    });
+    userEvent.type(screen.getByLabelText(/Hinta/), '12,34 ');
+    userEvent.tab();
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/tämän kentän on oltava kelvollinen numero/i)
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByLabelText(/Hinta/)).toHaveValue('12.34');
   });
 });
 

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -138,6 +138,12 @@ const EventForm = <T extends FormFields>({
       }) => {
         const { contactPersonId, image, isFree } = values;
         const imageSelected = Boolean(image);
+        const normalizePrice = (event: React.ChangeEvent<HTMLInputElement>) => {
+          const normalizedValue = event.target.value
+            .replace(/,/g, '.')
+            .replace(' ', '');
+          setFieldValue('price', normalizedValue, true);
+        };
         return (
           <>
             <BackButton onClick={goBack}>{t('common.back')}</BackButton>
@@ -352,6 +358,7 @@ const EventForm = <T extends FormFields>({
                             label={t('eventForm.offers.labelPrice')}
                             name="price"
                             component={TextInputField}
+                            onChange={normalizePrice}
                           />
                         </div>
                         <div className={styles.isFreeWrapper}>


### PR DESCRIPTION
PT-1489.

Price formatter / normalizer: 
- Converts commas to dots (while writing) 
- Does not allow spaces (while writing) 

![image](https://user-images.githubusercontent.com/389204/163201012-97d77161-4098-40da-b769-ed00bffaa0d4.png)
