### PR TITLE
chore: convert price field to a free text field

### DIFF
--- a/src/domain/event/__tests__/CreateEventPage.test.tsx
+++ b/src/domain/event/__tests__/CreateEventPage.test.tsx
@@ -346,6 +346,42 @@ describe('Event price section', () => {
     // to avoid "An update to Formik inside a test was not wrapped in act(...).""
     await screen.findByLabelText(/Tapahtuma on ilmainen/);
   });
+
+  test.each(['15 euroa', 'kysy tarjousta', '9.99', '9,99'])(
+    'price field allows a free text',
+    async (testText) => {
+      render(<CreateEventPage />, { mocks });
+      await screen.findByLabelText(/Tapahtuma on ilmainen/);
+      act(() => {
+        userEvent.click(screen.getByLabelText(/Tapahtuma on ilmainen/));
+      });
+      userEvent.type(screen.getByLabelText(/Hinta/), testText);
+      userEvent.tab();
+      await waitFor(() => {
+        expect(screen.getByTestId('event-form')).toHaveFormValues({
+          price: testText,
+        });
+      });
+    }
+  );
+
+  test('price field in a required field when is free is not checked', async () => {
+    render(<CreateEventPage />, { mocks });
+    await screen.findByLabelText(/Tapahtuma on ilmainen/);
+    act(() => {
+      userEvent.click(screen.getByLabelText(/Tapahtuma on ilmainen/));
+    });
+    expect(
+      screen.queryByText(/Tämä kenttä on pakollinen/i)
+    ).not.toBeInTheDocument();
+    userEvent.type(screen.getByLabelText(/Hinta/), '');
+    userEvent.tab();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Tämä kenttä on pakollinen/i)
+      ).toBeInTheDocument();
+    });
+  });
 });
 
 describe('Language selection', () => {

--- a/src/domain/event/eventForm/ValidationSchema.ts
+++ b/src/domain/event/eventForm/ValidationSchema.ts
@@ -4,12 +4,6 @@ import * as Yup from 'yup';
 import { Language } from '../../../types';
 import { VALIDATION_MESSAGE_KEYS } from '../../app/i18n/constants';
 
-const priceValidation = Yup.string()
-  // Price field is a string field which should contain positive numbers
-  .matches(/^\d+(\.\d+)?$/, VALIDATION_MESSAGE_KEYS.STRING_POSITIVENUMBER)
-  // Price should be required when event is not free
-  .required(VALIDATION_MESSAGE_KEYS.NUMBER_REQUIRED);
-
 const createMultiLanguageValidation = (
   languages: string[],
   rule: Yup.AnySchema
@@ -72,7 +66,7 @@ const createValidationSchemaYup = (selectedLanguages: Language[]) =>
     contactEmail: Yup.string().email(VALIDATION_MESSAGE_KEYS.EMAIL),
     price: Yup.string().when('isFree', {
       is: false,
-      then: priceValidation,
+      then: Yup.string().required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED),
     }),
     priceDescription: Yup.object().when('isFree', {
       is: false,


### PR DESCRIPTION
PT-1489 PT-1490. This branch is an alternative for #267 (where the price field number is formatted / normalized). This branch makes the field fully free text.