### PR TITLE
PT-1496 | Add root navigation item as the first link

### DIFF
--- a/src/domain/app/header/Header.tsx
+++ b/src/domain/app/header/Header.tsx
@@ -82,6 +82,13 @@ const Header: React.FC = () => {
               if (!!item.children?.length) {
                 return (
                   <Navigation.Dropdown label={item.title} key={item.id}>
+                    <Navigation.Item
+                      label={item.title}
+                      as={HeaderLink}
+                      to={`/${locale}${getCmsPath(
+                        stripLocaleFromUri(item.uri ?? '')
+                      )}`}
+                    />
                     {item.children.map((child) => (
                       <Navigation.Item
                         key={child.id}

--- a/src/headless-cms/components/__tests__/__snapshots__/CmsPage.test.tsx.snap
+++ b/src/headless-cms/components/__tests__/__snapshots__/CmsPage.test.tsx.snap
@@ -165,6 +165,16 @@ exports[`renders CMS page and navigation flow works 1`] = `
                   >
                     <a
                       class="Menu-module_item__3yQdE "
+                      href="/fi/cms-page/helsinki-liikkuu/"
+                    >
+                      <span
+                        class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
+                      >
+                        Mikä Kultus?
+                      </span>
+                    </a>
+                    <a
+                      class="Menu-module_item__3yQdE "
                       href="/fi/cms-page/helsinki-liikkuu/alisivu/"
                     >
                       <span


### PR DESCRIPTION
## Description :sparkles:

Adds root page links as the first link in the dropdown so that the root page is more easily accessible.

## Issues :bug:

### Closes :no_good_woman:

**[PT-1496](https://helsinkisolutionoffice.atlassian.net/browse/PT-1496)**

## Screenshots :camera_flash:

<img width="800" alt="Screenshot 2022-04-20 at 13 57 21" src="https://user-images.githubusercontent.com/9090689/164216328-da6bf6a8-496a-4fe0-adb0-83452b0a6ec1.png">
