### PR TITLE
feat: cms menu loading skipped when user is not logged in

### DIFF
--- a/src/domain/app/header/Header.tsx
+++ b/src/domain/app/header/Header.tsx
@@ -55,11 +55,10 @@ const Header: React.FC = () => {
     };
 
   const isAuthenticated = useSelector(isAuthenticatedSelector);
-
   const { data: myProfileData } = useMyProfileQuery({ skip: !isAuthenticated });
 
   const organisations: OrganisationNodeFieldsFragment[] =
-    myProfileData?.myProfile?.organisations.edges.map((edge) => ({
+    myProfileData?.myProfile?.organisations?.edges?.map((edge) => ({
       ...(edge?.node as OrganisationNodeFieldsFragment),
     })) || [];
 
@@ -74,7 +73,7 @@ const Header: React.FC = () => {
       logoLanguage={locale === 'sv' ? 'sv' : 'fi'}
       title={t('appName')}
     >
-      {!cmsMenuLoading && menuItems && (
+      {!cmsMenuLoading && menuItems?.length && (
         <Navigation.Row variant="inline">
           {menuItems
             ?.map((item, index) => {

--- a/src/domain/app/header/__tests__/Header.test.tsx
+++ b/src/domain/app/header/__tests__/Header.test.tsx
@@ -6,7 +6,13 @@ import { initCmsMenuItemsMocks } from '../../../../test/cmsMocks';
 import { server } from '../../../../test/msw/server';
 import { fakePage } from '../../../../utils/cmsMockDataUtils';
 import { fakePerson } from '../../../../utils/mockDataUtils';
-import { render, screen, userEvent } from '../../../../utils/testUtils';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from '../../../../utils/testUtils';
+import * as selectors from '../../../auth/selectors';
 import Header from '../Header';
 
 const profileResponse = {
@@ -74,9 +80,16 @@ describe('cimode in language selector', () => {
 });
 
 test('header renders cms menu items', async () => {
+  jest.spyOn(selectors, 'isAuthenticatedSelector').mockReturnValue(true);
   const { menuItems } = initCmsMenuItemsMocks();
   render(<Header />, { mocks });
-
+  await waitFor(() => {
+    expect(
+      screen.getByRole('button', {
+        name: /fi kielivalikko/i,
+      })
+    ).toBeInTheDocument();
+  });
   for (const menuItem of menuItems) {
     if (menuItem.children) {
       const dropdownButton = await screen.findByRole('button', {


### PR DESCRIPTION
PT-1474. The CMS menu items are not visible in the header when the user has not logged in yet.

<img width="1184" alt="image" src="https://user-images.githubusercontent.com/389204/192989678-f1e6c365-f04d-40ed-a39b-24a197eb92bd.png">

However, they should appear after a successfull login is done

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/389204/192989779-1f6763fe-bd79-4219-b1ee-ca02a7b40660.png">
