### PR TITLE
PT-1569 | fix: use correct contact infos in enrolment details

### DIFF
--- a/src/domain/occurrence/enrolmentDetails/EnrolmentDetails.tsx
+++ b/src/domain/occurrence/enrolmentDetails/EnrolmentDetails.tsx
@@ -273,23 +273,19 @@ const EnrolmentDetails: React.FC<EnrolmentDetailsProps> = ({
                   )}
                 />
 
-                {enrolment.person && (
-                  <>
-                    <EnrolmentInfoRow
-                      label={t('enrolment.enrolmentDetails.labelName')}
-                      value={enrolment.person.name}
-                      space
-                    />
-                    <EnrolmentInfoRow
-                      label={t('enrolment.enrolmentDetails.labelEmail')}
-                      value={enrolment.person.emailAddress}
-                    />
-                    <EnrolmentInfoRow
-                      label={t('enrolment.enrolmentDetails.labelPhoneNumber')}
-                      value={enrolment.person.phoneNumber}
-                    />
-                  </>
-                )}
+                <EnrolmentInfoRow
+                  label={t('enrolment.enrolmentDetails.labelName')}
+                  value={enrolment.studyGroup.person.name}
+                  space
+                />
+                <EnrolmentInfoRow
+                  label={t('enrolment.enrolmentDetails.labelEmail')}
+                  value={enrolment.studyGroup.person.emailAddress}
+                />
+                <EnrolmentInfoRow
+                  label={t('enrolment.enrolmentDetails.labelPhoneNumber')}
+                  value={enrolment.studyGroup.person.phoneNumber}
+                />
 
                 <EnrolmentInfoRow
                   label={t('enrolment.enrolmentDetails.labelStudyGroupName')}
@@ -315,19 +311,25 @@ const EnrolmentDetails: React.FC<EnrolmentDetailsProps> = ({
                   value={enrolment.studyGroup.extraNeeds}
                 />
 
-                <EnrolmentInfoRow
-                  label={t('enrolment.enrolmentDetails.labelResponsiblePerson')}
-                  value={enrolment.studyGroup.person.name}
-                  space
-                />
-                <EnrolmentInfoRow
-                  label={t('enrolment.enrolmentDetails.labelEmail')}
-                  value={enrolment.studyGroup.person.emailAddress}
-                />
-                <EnrolmentInfoRow
-                  label={t('enrolment.enrolmentDetails.labelPhoneNumber')}
-                  value={enrolment.studyGroup.person.phoneNumber}
-                />
+                {enrolment.person && (
+                  <>
+                    <EnrolmentInfoRow
+                      label={t(
+                        'enrolment.enrolmentDetails.labelResponsiblePerson'
+                      )}
+                      value={enrolment.person.name}
+                      space
+                    />
+                    <EnrolmentInfoRow
+                      label={t('enrolment.enrolmentDetails.labelEmail')}
+                      value={enrolment.person.emailAddress}
+                    />
+                    <EnrolmentInfoRow
+                      label={t('enrolment.enrolmentDetails.labelPhoneNumber')}
+                      value={enrolment.person.phoneNumber}
+                    />
+                  </>
+                )}
 
                 <EnrolmentInfoRow
                   label={t('enrolment.enrolmentDetails.labelNotifications')}


### PR DESCRIPTION
## Description :sparkles:

### fix: use correct contact infos in enrolment details

refs PT-1569 (the contact info details were incorrectly placed)

## Issues :bug:
### Closes :no_good_woman:
**[PT-1569](https://helsinkisolutionoffice.atlassian.net/browse/PT-1569)**

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

Set up palvelutarjotin, palvelutarjotin-admin, palvelutarjotin-ui and tunnistamo locally, created an event, enrolled in it and then looked up the enrolment details in the palvelutarjotin-admin UI.

## Screenshots :camera_flash:

#### Before changes in this PR:
![before](https://user-images.githubusercontent.com/77663720/220357690-08e7b52e-ec5c-4313-9230-acdf44edc039.png)

#### After changes in this PR:
![after](https://user-images.githubusercontent.com/77663720/220357720-6f4a7ff5-44e4-4a13-ad50-709c33537d55.png)

## Additional notes :spiral_notepad:

[PT-1569]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ