### PR TITLE
ci: add version and release information in the (Nginx) readiness probe

### DIFF
--- a/.prod/nginx.conf.template
+++ b/.prod/nginx.conf.template
@@ -1,3 +1,9 @@
+### nginx.conf.template -- The following environment variables should be set by the Dockerfile.
+# - APP_VERSION
+# - REACT_APP_BUILDTIME
+# - REACT_APP_RELEASE
+# - REACT_APP_COMMITHASH
+###
 server {
     listen       8080;
     server_name  localhost;
@@ -9,7 +15,8 @@ server {
     }
 
     location /readiness {
-        return 200 'OK';
+        default_type application/json;
+        return 200 '{ "status": "ok", "release": "${REACT_APP_RELEASE}", "packageVersion": "${APP_VERSION}", "commitHash": "${REACT_APP_COMMITHASH}", "buildTime": "${REACT_APP_BUILDTIME}" }';
     }
 
     location /static {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "yup": "^1.2.0"
   },
   "scripts": {
+    "app:version": "echo \"$npm_package_version\"",
     "prepare": "husky install",
     "start": "craco start",
     "build": "craco build",

--- a/src/domain/app/routes/constants.ts
+++ b/src/domain/app/routes/constants.ts
@@ -18,6 +18,7 @@ export enum ROUTES {
   SILENT_CALLBACK = '/silent-callback',
   ENROLMENT_REPORT = '/events/:id/export-enrolments',
   CMS_PAGE = `/cms-page/:slug`,
+  /** @deprecated there is no need for `/api/version` when it's served from `/readiness` -probe (in PT-1698). This route has originally been implemented as a compromise. */
   API_VERSION = '/api/version',
 }
 


### PR DESCRIPTION
PT-1698

Read the following environment variables that are set in the pipeline process and set them in the respond of the Nginx `/readiness` -probe:
- RELEASE
- APP_VERSION
- COMMITHASH
- BUILD_TIME
---- 
Note: same work in Kukkuu https://github.com/City-of-Helsinki/kukkuu-admin/pull/243
