### PR TITLE
Fix enrolment edit link and form data initialization

### DIFF
--- a/src/domain/enrolment/EditEnrolmentPage.tsx
+++ b/src/domain/enrolment/EditEnrolmentPage.tsx
@@ -170,18 +170,12 @@ const EditorEnrolmentPage: React.FC = () => {
                 {t('enrolment.editEnrolmentBackButton')}
               </BackButton>
               <h1>{t('enrolment.editEnrolmentTitle')}</h1>
-              {!!minGroupSize && !!maxGroupSize ? (
-                <EnrolmentForm
-                  onSubmit={handleSubmit}
-                  initialValues={initialValues}
-                  minGroupSize={minGroupSize}
-                  maxGroupSize={maxGroupSize}
-                />
-              ) : (
-                <Notification label="Virhe" type="error">
-                  Virhe lomakkeen alustuksessa
-                </Notification>
-              )}
+              <EnrolmentForm
+                onSubmit={handleSubmit}
+                initialValues={initialValues}
+                minGroupSize={minGroupSize}
+                maxGroupSize={maxGroupSize}
+              />
             </Container>
           </div>
         )}

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -55,8 +55,8 @@ interface Props {
 
 const EnrolmentForm: React.FC<Props> = ({
   initialValues = defaultInitialValues,
-  minGroupSize = 10,
-  maxGroupSize = 20,
+  minGroupSize = 1,
+  maxGroupSize,
   onSubmit,
 }) => {
   const { t } = useTranslation();

--- a/src/domain/enrolment/enrolmentForm/ValidationSchema.ts
+++ b/src/domain/enrolment/enrolmentForm/ValidationSchema.ts
@@ -7,7 +7,7 @@ export default function getValidationSchema({
   maxGroupSize,
 }: {
   minGroupSize: number;
-  maxGroupSize: number;
+  maxGroupSize?: number;
 }) {
   const validateSumOfSizePair = (
     sizePair: number | undefined,
@@ -19,23 +19,20 @@ export default function getValidationSchema({
     // Validate a single field against the total min and max sizes.
     // The used validation error message will be the same for both the fields.
     // This is also preventing negative param.max to occur in validation.
+    schema = schema
+      // Min-limit is current a gap to minimum group size.
+      .min(sizePair != null ? minGroupSize - sizePair : minGroupSize, () => ({
+        min: minGroupSize,
+        key: totalMinLimitValidationMessage,
+      }));
 
-    if (
-      !sizePair ||
-      sizePair < 0 ||
-      sizePair < minGroupSize ||
-      sizePair > maxGroupSize
-    ) {
+    if (!maxGroupSize) {
+      return schema;
+    }
+
+    if (!sizePair || sizePair > maxGroupSize) {
       return (
         schema
-          // Min-limit is current a gap to minimum group size.
-          .min(
-            sizePair != null ? minGroupSize - sizePair : minGroupSize,
-            () => ({
-              min: minGroupSize,
-              key: totalMinLimitValidationMessage,
-            })
-          )
           // Max-limit is maximum group size
           .max(maxGroupSize, (param) => ({
             max: param.max,

--- a/src/domain/occurrence/enrolmentDetails/EnrolmentDetails.tsx
+++ b/src/domain/occurrence/enrolmentDetails/EnrolmentDetails.tsx
@@ -153,7 +153,7 @@ const EnrolmentDetails: React.FC<EnrolmentDetailsProps> = ({
 
   const handleEditEnrolment = () => {
     pushWithReturnPath(
-      `/${locale}${ROUTES.EDIT_ENROLMENT.replace(':eventId', eventId).replace(
+      `${ROUTES.EDIT_ENROLMENT.replace(':eventId', eventId).replace(
         ':enrolmentId',
         enrolmentId
       )}`


### PR DESCRIPTION
PT-1706

### The errors

The errenous section of the site:
<img width="1098" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin-admin/assets/389204/a256f97e-797a-4bcb-906f-ee18322b10c3">

1. When the "Muokkaa"  /edit button was clicked, the locale was added twice and the page was rendered as an empty grey page

<img width="1085" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin-admin/assets/389204/0568caf1-0ed0-4fec-97ad-d7c3c57dbfd7">


Solution: Remove the explicit locale set from the link path.

2. When the "Muokkaa" /edit was clicked from the dropdown menu, the locale was not added twice, but another error which was related to the form data initialization was thrown

<img width="1099" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin-admin/assets/389204/f6474307-5c6d-40a6-aff9-e988c913d762">

Solution: This was a special case and the error was always written in Finnish, when there were no audience limits set for a study group.

### The page that should have been shown and is now shown after the fixes

<img width="1066" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin-admin/assets/389204/581ebad0-bcdf-49ba-b304-5a40637533e2">

----

EDIT: There was also a 3rd error which was in the group size validation. There were some default limits which was a bad practise. Now, the min group size is set to 1 and maximum can be left undefined or it's calculated from the remaining space left. IT should als obe noted that this is an admin form -- not for public users.