### PR TITLE
PT-1714 | fix(docker): pass REACT_APP_ORIGIN as argument to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,9 @@ ARG REACT_APP_API_REPORT_URI
 # Linkedevents api url
 ARG REACT_APP_LINKEDEVENTS_API_URI
 
+# Application's origin (i.e. where this application is hosted)
+ARG REACT_APP_ORIGIN
+
 # Release information
 ARG REACT_APP_RELEASE
 ARG REACT_APP_COMMITHASH


### PR DESCRIPTION
## Description :sparkles:

### fix(docker): pass REACT_APP_ORIGIN as argument to Dockerfile

refs PT-1714 (this added REACT_APP_ORIGIN)

## Issues :bug:
### Closes :no_good_woman:

### Related :handshake:

[PT-1714](https://helsinkisolutionoffice.atlassian.net/browse/PT-1714)

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

[PT-1714]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ