### PR TITLE
PT-1725 | fix: fix production styles & running docker compose

### DIFF
--- a/.env
+++ b/.env
@@ -14,3 +14,19 @@ REACT_APP_SENTRY_DSN=
 REACT_APP_ENVIRONMENT=local
 REACT_APP_APPLICATION_NAME=$npm_package_name
 REACT_APP_VERSION=$npm_package_version
+
+# Environment variables for the development environment:
+#
+# Copied here from .env.development because docker compose build args doesn't support
+# any other files except .env, env_file setting affects environment variables in docker
+# compose but it does not affect build args.
+#
+# So in order to support docker compose build args and environment variables being the
+# same they have to either be put them into .env (no other file will suffice, only .env)
+# or e.g. set them using a script to the environment before running docker compose.
+REACT_APP_API_URI=https://kultus.api.test.hel.ninja/graphql
+REACT_APP_API_REPORT_URI=https://kultus.api.test.hel.ninja/reports
+REACT_APP_OIDC_AUTHORITY=https://tunnistamo.test.hel.ninja
+REACT_APP_OIDC_CLIENT_ID=kultus-provider-test
+REACT_APP_OIDC_SCOPE="openid profile https://api.hel.fi/auth/kultusapitest"
+REACT_APP_LINKEDEVENTS_API_URI=https://api.hel.fi/linkedevents-test/v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ===============================================
-FROM registry.access.redhat.com/ubi9/nodejs-18 AS appbase
+FROM registry.access.redhat.com/ubi9/nodejs-20 AS appbase
 # ===============================================
 
 # install yarn

--- a/src/domain/app/footer/footer.module.scss
+++ b/src/domain/app/footer/footer.module.scss
@@ -3,5 +3,5 @@
 .footer {
   display: grid;
   margin-top: calc(var(--spacing-xl) * -1);
-  --footer-background: var(--color-black-10);
+  --footer-background: var(--color-black-10) !important;
 }

--- a/src/domain/app/header/header.module.scss
+++ b/src/domain/app/header/header.module.scss
@@ -1,22 +1,25 @@
+// WORKAROUND: Marked all styles !important so they apply even if CSS order varies.
+//             Switching from CRA/Craco to Vite might remove the need for this hack.
+@import 'layout';
 @import 'variables';
 
 @mixin active {
-  color: var(--color-white);
-  background-color: var(--color-bus);
+  color: var(--color-white) !important;
+  background-color: var(--color-bus) !important;
 }
 
 .userMenuDropdown {
-  border-color: var(--color-black-90);
+  border-color: var(--color-black-90) !important;
 }
 
 .dropdownButton {
-  min-width: $breakpoint-xs;
-  text-align: left;
-  justify-content: left;
+  min-width: $breakpoint-xs !important;
+  text-align: left !important;
+  justify-content: left !important;
   max-height: 40px !important;
-  --min-size: 40px;
-  font-weight: normal;
-  color: var(--color-black-90);
+  --min-size: 40px !important;
+  font-weight: normal !important;
+  color: var(--color-black-90) !important;
 
   svg {
     // To make sure the icon size stays the same,
@@ -28,7 +31,7 @@
   }
 
   &:focus {
-    outline-color: var(--color-focus-outline);
+    outline-color: var(--color-focus-outline) !important;
   }
 
   &:hover {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,7 +1,7 @@
 @import './vendor/normalize';
-
 @import 'fonts';
 @import 'layout';
+@import 'variables';
 
 html {
   height: 100%;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,5 +1,3 @@
-@import '~hds-design-tokens/lib/all.scss';
-
 // Margin and padding
 $basePadding: 1.25rem;
 $largePadding: 2.5rem;


### PR DESCRIPTION
## Description :sparkles:

### fix: fix production styles & running docker compose

Docker compose related:
 - Fix running docker compose by copy-pasting .env.development into .env
   because docker compose build args doesn't support any other files
   except .env, env_file setting affects environment variables in docker
   compose but it does not affect build args.
 - So in order to support docker compose build args and environment
   variables being the same they have to either be put them into .env
   (no other file will suffice, only .env) or e.g. set them using a
   script to the environment before running docker compose.

Production styles related:
 - Fix production styles by marking all styles in header.module.scss
   as !important and --footer-background in footer.module.scss as
   !important.
   - This is a workaround to make sure styles are applied even if CSS
	 order varies. Switching from Craco to Vite might remove the need
	 for this hack. Tried disabling CSS chunking in webpack but either
	 it didn't work or if it did work it didn't help.

refs PT-1725

## Issues :bug:
### Closes :no_good_woman:

### Related :handshake:

[PT-1725](https://helsinkisolutionoffice.atlassian.net/browse/PT-1725)

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

[PT-1725]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ