### PR TITLE
PT-1725 | fix: use correct Linked Events test URL in testing

### DIFF
--- a/.env
+++ b/.env
@@ -29,4 +29,4 @@ VITE_APP_API_REPORT_URI=https://kultus.api.test.hel.ninja/reports
 VITE_APP_OIDC_AUTHORITY=https://tunnistamo.test.hel.ninja
 VITE_APP_OIDC_CLIENT_ID=kultus-provider-test
 VITE_APP_OIDC_SCOPE="openid profile https://api.hel.fi/auth/kultusapitest"
-VITE_APP_LINKEDEVENTS_API_URI=https://api.hel.fi/linkedevents-test/v1
+VITE_APP_LINKEDEVENTS_API_URI=https://linkedevents.api.test.hel.ninja/v1

--- a/.env.development
+++ b/.env.development
@@ -10,4 +10,4 @@ VITE_APP_API_REPORT_URI=https://kultus.api.test.hel.ninja/reports
 VITE_APP_OIDC_AUTHORITY=https://tunnistamo.test.hel.ninja
 VITE_APP_OIDC_CLIENT_ID=kultus-provider-test
 VITE_APP_OIDC_SCOPE="openid profile https://api.hel.fi/auth/kultusapitest"
-VITE_APP_LINKEDEVENTS_API_URI=https://api.hel.fi/linkedevents-test/v1
+VITE_APP_LINKEDEVENTS_API_URI=https://linkedevents.api.test.hel.ninja/v1

--- a/src/domain/event/__tests__/EventDetailsPage.test.tsx
+++ b/src/domain/event/__tests__/EventDetailsPage.test.tsx
@@ -215,7 +215,7 @@ test('renders correct information and delete works', async () => {
   const eventImage = screen.getByAltText('Kuvan vaihtoehtoinen teksti');
   expect(eventImage).toHaveAttribute(
     'src',
-    'https://api.hel.fi/linkedevents-test/media/images/test.png'
+    'https://linkedevents.api.test.hel.ninja/media/images/test.png'
   );
 
   const deleteButton = screen.getByRole('button', { name: 'Poista tapahtuma' });

--- a/src/domain/event/eventBasicInfo/__tests__/__snapshots__/EventBasicInfo.test.tsx.snap
+++ b/src/domain/event/eventBasicInfo/__tests__/__snapshots__/EventBasicInfo.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`matches snapshot 1`] = `
         <img
           alt="Testikuva"
           class="image"
-          src="https://api.hel.fi/linkedevents-test/media/images/test.png"
+          src="https://linkedevents.api.test.hel.ninja/media/images/test.png"
         />
       </div>
       <div

--- a/src/domain/event/eventPreviewCard/__tests__/__snapshots__/EventPreviewCard.test.tsx.snap
+++ b/src/domain/event/eventPreviewCard/__tests__/__snapshots__/EventPreviewCard.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders event information correctly and matches snapshot 1`] = `
   >
     <div
       class="imageWrapper"
-      style="background-image: url(https://api.hel.fi/linkedevents-test/media/images/test.png);"
+      style="background-image: url(https://linkedevents.api.test.hel.ninja/media/images/test.png);"
     />
     <div
       class="contentWrapper"

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -305,7 +305,7 @@ export const fakeImage = (overrides?: Partial<Image>): Image => ({
   ),
   license: 'cc_by',
   name: faker.word.words(),
-  url: 'https://api.hel.fi/linkedevents-test/media/images/test.png',
+  url: 'https://linkedevents.api.test.hel.ninja/media/images/test.png',
   cropping: '59,0,503,444',
   photographerName: faker.person.firstName(),
   altText: faker.word.words(),


### PR DESCRIPTION
## Description :sparkles:

### fix: use correct Linked Events test URL in testing

refs PT-1725

## Issues :bug:
### Closes :no_good_woman:

### Related :handshake:
[PT-1725](https://helsinkisolutionoffice.atlassian.net/browse/PT-1725)

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

[PT-1725]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ