### PR TITLE
PT-1725 | fix: fix event links with double locale, e.g. /fi/fi/ -> /fi/

### DIFF
--- a/src/domain/event/EditEventPage.tsx
+++ b/src/domain/event/EditEventPage.tsx
@@ -59,7 +59,7 @@ const useEventFormEditSubmit = (
   );
 
   const goToOccurrencesPage = () => {
-    id && pushWithLocale(`${ROUTES.CREATE_OCCURRENCE.replace(':id', id)}`);
+    id && pushWithLocale(ROUTES.CREATE_OCCURRENCE.replace(':id', id));
   };
 
   const navigateAfterSave = () => {

--- a/src/domain/event/EventDetailsPage.tsx
+++ b/src/domain/event/EventDetailsPage.tsx
@@ -149,8 +149,7 @@ const EventDetailsPage = () => {
   };
 
   const handleEditEventClick = () => {
-    id &&
-      pushWithReturnPath(`/${locale}${ROUTES.EDIT_EVENT.replace(':id', id)}`);
+    id && pushWithReturnPath(ROUTES.EDIT_EVENT.replace(':id', id));
   };
 
   return (

--- a/src/domain/event/EventPreviewPage.tsx
+++ b/src/domain/event/EventPreviewPage.tsx
@@ -31,8 +31,7 @@ const EventPage: React.FC = () => {
     getEventFields(eventData?.event, locale);
 
   const goToSummaryPage = () => {
-    eventId &&
-      pushWithLocale(`${ROUTES.EVENT_SUMMARY}`.replace(':id', eventId));
+    eventId && pushWithLocale(ROUTES.EVENT_SUMMARY.replace(':id', eventId));
   };
 
   return (

--- a/src/domain/event/EventSummaryPage.tsx
+++ b/src/domain/event/EventSummaryPage.tsx
@@ -99,18 +99,15 @@ const EventSummaryPage: React.FC = () => {
   };
 
   const goToEventDetailsPage = () => {
-    eventId &&
-      pushWithReturnPath(`${ROUTES.EVENT_DETAILS.replace(':id', eventId)}`);
+    eventId && pushWithReturnPath(ROUTES.EVENT_DETAILS.replace(':id', eventId));
   };
 
   const goToCreateOccurrence = () => {
-    eventId &&
-      pushWithLocale(`${ROUTES.CREATE_OCCURRENCE.replace(':id', eventId)}`);
+    eventId && pushWithLocale(ROUTES.CREATE_OCCURRENCE.replace(':id', eventId));
   };
 
   const copyEventToNewTemplate = () => {
-    eventId &&
-      pushWithReturnPath(`${ROUTES.COPY_EVENT.replace(':id', eventId)}`);
+    eventId && pushWithReturnPath(ROUTES.COPY_EVENT.replace(':id', eventId));
   };
 
   const goToHome = () => pushWithLocale(ROUTES.HOME);

--- a/src/domain/occurrence/CreateOccurrencePage.tsx
+++ b/src/domain/occurrence/CreateOccurrencePage.tsx
@@ -222,8 +222,7 @@ const CreateOccurrencePage: React.FC = () => {
   };
 
   const goToSummaryPage = () => {
-    eventId &&
-      pushWithLocale(`${ROUTES.EVENT_SUMMARY}`.replace(':id', eventId));
+    eventId && pushWithLocale(ROUTES.EVENT_SUMMARY.replace(':id', eventId));
   };
 
   const handleSelectedLanguagesChange = (

--- a/src/domain/occurrence/enrolmentDetails/EnrolmentDetails.tsx
+++ b/src/domain/occurrence/enrolmentDetails/EnrolmentDetails.tsx
@@ -151,10 +151,10 @@ const EnrolmentDetails: React.FC<EnrolmentDetailsProps> = ({
 
   const handleEditEnrolment = () => {
     pushWithReturnPath(
-      `${ROUTES.EDIT_ENROLMENT.replace(':eventId', eventId).replace(
+      ROUTES.EDIT_ENROLMENT.replace(':eventId', eventId).replace(
         ':enrolmentId',
         enrolmentId
-      )}`
+      )
     );
   };
 

--- a/src/domain/occurrence/occurrenceInfo/OccurrenceInfo.tsx
+++ b/src/domain/occurrence/occurrenceInfo/OccurrenceInfo.tsx
@@ -48,9 +48,7 @@ const OccurrenceInfo: React.FC<Props> = ({ event, occurrence }) => {
   const placeId = occurrence.placeId || event.location?.id;
 
   const goToEventDetailsPage = () => {
-    pushWithReturnPath(
-      `/${locale}${ROUTES.EVENT_DETAILS.replace(':id', eventId || '')}`
-    );
+    pushWithReturnPath(ROUTES.EVENT_DETAILS.replace(':id', eventId || ''));
   };
 
   const getOccurrenceDateTimeString = () => {


### PR DESCRIPTION
## Description :sparkles:

### fix: fix event links with double locale, e.g. /fi/fi/ -> /fi/

also:
 - remove unnecessary string interpolations

refs PT-1725

## Issues :bug:
### Closes :no_good_woman:

### Related :handshake:
[PT-1725](https://helsinkisolutionoffice.atlassian.net/browse/PT-1725)

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: