### PR TITLE
feat: unit place selector search filter parameter

### DIFF
--- a/src/domain/enrolment/__tests__/EditEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/EditEnrolmentPage.test.tsx
@@ -381,7 +381,26 @@ describe('UnitField', () => {
   }, 20_000);
 
   it('renders a list of schools and kindergartens in unit id field', async () => {
-    await setupUnitFieldTest();
+    await setupUnitFieldTest([
+      createSchoolsAndKindergartensListQueryMock(
+        10,
+        [
+          { id: 'test:place1', name: fakeLocalizedObject('place1') },
+          { id: 'test:place2', name: fakeLocalizedObject('place2') },
+          { id: 'test:place12', name: fakeLocalizedObject('place12') },
+          { id: 'test:place123', name: fakeLocalizedObject('place123') },
+        ],
+        'place'
+      ),
+      createSchoolsAndKindergartensListQueryMock(
+        10,
+        [
+          { id: 'test:place12', name: fakeLocalizedObject('place12') },
+          { id: 'test:place123', name: fakeLocalizedObject('place123') },
+        ],
+        'place12'
+      ),
+    ]);
 
     // Type to unit id field
     await userEvent.type(getUnitFieldInput(), 'place');
@@ -460,7 +479,17 @@ describe('UnitField', () => {
       }),
     ];
 
-    await setupUnitFieldTest(placeMocks);
+    await setupUnitFieldTest([
+      ...placeMocks,
+      createSchoolsAndKindergartensListQueryMock(
+        10,
+        [
+          { id: 'test:place12', name: fakeLocalizedObject('place12') },
+          { id: 'test:place123', name: fakeLocalizedObject('place123') },
+        ],
+        'place12'
+      ),
+    ]);
 
     await userEvent.type(getUnitFieldInput(), 'place12');
 
@@ -477,7 +506,16 @@ describe('UnitField', () => {
   }, 20_000);
 
   it('shows "no place found" text in autosuggest div next to invalid input', async () => {
-    await setupUnitFieldTest(undefined);
+    await setupUnitFieldTest([
+      createSchoolsAndKindergartensListQueryMock(
+        10,
+        [
+          { id: 'test:place12', name: fakeLocalizedObject('place12') },
+          { id: 'test:place123', name: fakeLocalizedObject('place123') },
+        ],
+        'place12'
+      ),
+    ]);
 
     await userEvent.type(getUnitFieldInput(), 'place12');
 
@@ -499,6 +537,14 @@ describe('UnitField', () => {
         id: 'test:place12',
         name: fakeLocalizedObject('place12'),
       }),
+      createSchoolsAndKindergartensListQueryMock(
+        10,
+        [
+          { id: 'test:place12', name: fakeLocalizedObject('place12') },
+          { id: 'test:place123', name: fakeLocalizedObject('place123') },
+        ],
+        'place12'
+      ),
     ]);
 
     await userEvent.type(

--- a/src/domain/place/UnitPlaceSelector.tsx
+++ b/src/domain/place/UnitPlaceSelector.tsx
@@ -45,12 +45,15 @@ const UnitPlaceSelector: React.FC<Props> = ({
   disabled,
 }) => {
   const [inputValue, setInputValue] = React.useState('');
-  const searchValue = useDebounce(inputValue, 100);
+  const searchValue = useDebounce(inputValue, 500);
 
   const apolloClient = useApolloClient();
 
   const { data: unitsData, loading } = useSchoolsAndKindergartensListQuery({
     skip: !searchValue,
+    variables: {
+      search: searchValue,
+    },
   });
 
   const locale = useLocale();
@@ -73,15 +76,10 @@ const UnitPlaceSelector: React.FC<Props> = ({
   };
 
   const placeOptions =
-    unitsData?.schoolsAndKindergartensList?.data
-      .map((place) => ({
-        label: getOptionLabel(place as Place),
-        value: place.id || '',
-      }))
-      // Filter the results with a search value!
-      .filter((place) =>
-        place.label.toLowerCase().includes(searchValue.toLowerCase())
-      ) || [];
+    unitsData?.schoolsAndKindergartensList?.data.map((place) => ({
+      label: getOptionLabel(place as Place),
+      value: place.id || '',
+    })) || [];
 
   const handleBlur = (
     option: AutoSuggestOption | AutoSuggestOption[] | null

--- a/src/domain/place/query.ts
+++ b/src/domain/place/query.ts
@@ -51,8 +51,8 @@ export const QUERY_PLACE = gql`
       }
     }
   }
-  query SchoolsAndKindergartensList {
-    schoolsAndKindergartensList {
+  query SchoolsAndKindergartensList($search: String) {
+    schoolsAndKindergartensList(search: $search) {
       meta {
         count
       }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -1665,6 +1665,11 @@ export type QueryPopularKultusKeywordsArgs = {
 };
 
 
+export type QuerySchoolsAndKindergartensListArgs = {
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
+
 export type QueryStudyLevelArgs = {
   id: Scalars['ID']['input'];
 };
@@ -2459,7 +2464,9 @@ export type PlacesQueryVariables = Exact<{
 
 export type PlacesQuery = { __typename?: 'Query', places?: { __typename?: 'PlaceListResponse', meta: { __typename?: 'Meta', count?: number | null, next?: string | null, previous?: string | null }, data: Array<{ __typename?: 'Place', id?: string | null, internalId: string, name?: { __typename?: 'LocalisedObject', en?: string | null, fi?: string | null, sv?: string | null } | null, streetAddress?: { __typename?: 'LocalisedObject', en?: string | null, fi?: string | null, sv?: string | null } | null, addressLocality?: { __typename?: 'LocalisedObject', en?: string | null, fi?: string | null, sv?: string | null } | null, telephone?: { __typename?: 'LocalisedObject', en?: string | null, fi?: string | null, sv?: string | null } | null }> } | null };
 
-export type SchoolsAndKindergartensListQueryVariables = Exact<{ [key: string]: never; }>;
+export type SchoolsAndKindergartensListQueryVariables = Exact<{
+  search?: InputMaybe<Scalars['String']['input']>;
+}>;
 
 
 export type SchoolsAndKindergartensListQuery = { __typename?: 'Query', schoolsAndKindergartensList?: { __typename?: 'ServiceUnitNameListResponse', meta: { __typename?: 'Meta', count?: number | null }, data: Array<{ __typename?: 'ServiceUnitNode', id: string, name?: { __typename?: 'LocalisedObject', fi?: string | null, sv?: string | null, en?: string | null } | null }> } | null };
@@ -4519,8 +4526,8 @@ export type PlacesLazyQueryHookResult = ReturnType<typeof usePlacesLazyQuery>;
 export type PlacesSuspenseQueryHookResult = ReturnType<typeof usePlacesSuspenseQuery>;
 export type PlacesQueryResult = Apollo.QueryResult<PlacesQuery, PlacesQueryVariables>;
 export const SchoolsAndKindergartensListDocument = gql`
-    query SchoolsAndKindergartensList {
-  schoolsAndKindergartensList {
+    query SchoolsAndKindergartensList($search: String) {
+  schoolsAndKindergartensList(search: $search) {
     meta {
       count
     }
@@ -4548,6 +4555,7 @@ export const SchoolsAndKindergartensListDocument = gql`
  * @example
  * const { data, loading, error } = useSchoolsAndKindergartensListQuery({
  *   variables: {
+ *      search: // value for 'search'
  *   },
  * });
  */

--- a/src/test/apollo-mocks/schoolsAndKindergartensListMock.ts
+++ b/src/test/apollo-mocks/schoolsAndKindergartensListMock.ts
@@ -8,11 +8,12 @@ import { fakePlaces } from '../../utils/mockDataUtils';
 
 export const createSchoolsAndKindergartensListQueryMock = (
   count = 1,
-  places?: Partial<Place>[]
+  places?: Partial<Place>[],
+  search?: string
 ): MockedResponse => ({
   request: {
     query: SchoolsAndKindergartensListDocument,
-    variables: {},
+    variables: { search },
   },
   result: {
     data: {


### PR DESCRIPTION
PT-1733 PT-1743.
The unit place selector now uses a schools and kindergaratens list query with search-filter-parameter, since the API has changed the data source and the service now supports using it. So instead of always loading everything to memory, the client now requests a new options everytime when the search input changes.

NOTE: Needs https://github.com/City-of-Helsinki/palvelutarjotin/pull/350 as a dependency.