### PR TITLE
PT-1748 | docs: remove CREATE_SUPERUSER variable from backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,15 @@ admin http://tunnistamo-backend:8000/admin/oidc_provider/client/
 
 Clone the [palvelutarjotin repository](https://github.com/City-of-Helsinki/palvelutarjotin) and follow the instructions
 for running palvelutarjotin with docker. Before running `docker-compose up` set the following settings in
-palvelutarjotin roots `docker-compose.env.yaml`:
+palvelutarjotin root's `docker-compose.env.yaml`:
 
 - DEBUG=1
 - CORS_ORIGIN_ALLOW_ALL=1
 - APPLY_MIGRATIONS=1
-- CREATE_SUPERUSER=1
 - TOKEN_AUTH_AUTHSERVER_URL=http://tunnistamo-backend:8000/openid
+
+If you do not have a super user / admin to administrate the API yet, you can create one with
+`docker compose run django python manage.py add_admin_user -u admin -p admin -e admin@example.com`.
 
 ### palvelutarjotin-admin-ui
 


### PR DESCRIPTION
## Description :sparkles:

### docs: remove CREATE_SUPERUSER variable from backend

The backend part related to this change:
 - https://github.com/City-of-Helsinki/palvelutarjotin/pull/352

refs PT-1748

## Issues :bug:
### Closes :no_good_woman:

### Related :handshake:

[PT-1748](https://helsinkisolutionoffice.atlassian.net/browse/PT-1748)
https://github.com/City-of-Helsinki/palvelutarjotin/pull/352
https://dev.azure.com/City-of-Helsinki/kultus/_git/kultus-pipelines/pullrequest/8807

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

[PT-1748]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ