### PR TITLE
PT-1777 | feat: helsinki profile header link

### DIFF
--- a/.env
+++ b/.env
@@ -35,3 +35,4 @@ VITE_APP_OIDC_AUTHORITY=https://tunnistus.test.hel.ninja/auth/realms/helsinki-tu
 VITE_APP_OIDC_CLIENT_ID=kultus-admin-ui-dev
 VITE_APP_OIDC_SCOPE="openid profile email"
 VITE_APP_OIDC_AUTOMATIC_SILENT_RENEW_ENABLED=1
+VITE_APP_HELSINKI_PROFILE_URL=https://profiili.test.hel.ninja/loginsso

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,9 @@ ARG VITE_APP_LINKEDEVENTS_API_URI
 # Application's origin (i.e. where this application is hosted)
 ARG VITE_APP_ORIGIN
 
+# Helsinki profile URL
+ARG VITE_APP_HELSINKI_PROFILE_URL
+
 # Release information
 ARG VITE_APP_RELEASE
 ARG VITE_APP_COMMITHASH

--- a/src/domain/app/AppConfig.ts
+++ b/src/domain/app/AppConfig.ts
@@ -28,6 +28,13 @@ class AppConfig {
     return new URL(this.apiUri).origin;
   }
 
+  static get helsinkiProfileUrl() {
+    return getEnvOrError(
+      import.meta.env.VITE_APP_HELSINKI_PROFILE_URL,
+      'VITE_APP_HELSINKI_PROFILE_URL'
+    );
+  }
+
   static get oidcAuthority() {
     return getEnvOrError(
       import.meta.env.VITE_APP_OIDC_AUTHORITY,

--- a/src/domain/app/header/Header.tsx
+++ b/src/domain/app/header/Header.tsx
@@ -2,6 +2,7 @@ import {
   Button as HDSButton,
   Header as HDSHeader,
   IconAngleRight,
+  IconLinkExternal,
   IconSignout,
   IconUser,
   useMediaQueryLessThan,
@@ -142,6 +143,16 @@ const UserNavigation: React.FC<{
     pushWithLocale(ROUTES.MY_PROFILE);
   };
 
+  const goToHelsinkiProfile = () => {
+    if (typeof window !== 'undefined') {
+      window.open(
+        AppConfig.helsinkiProfileUrl,
+        '_blank',
+        'noopener,noreferrer'
+      );
+    }
+  };
+
   const activeOrganisation = useAppSelector(activeOrganisationSelector);
 
   const changeActiveOrganisation = (id: string) => {
@@ -166,6 +177,15 @@ const UserNavigation: React.FC<{
         variant="supplementary"
       >
         {t('header.userMenu.openMyProfile')}
+      </HDSButton>
+      <HDSButton
+        key={`go-to-profile`}
+        className={styles.dropdownButton}
+        iconLeft={<IconLinkExternal />}
+        onClick={goToHelsinkiProfile}
+        variant="supplementary"
+      >
+        {t('header.userMenu.openHelsinkiProfile')}
       </HDSButton>
       {organisations?.map((organisation) => (
         <HDSButton

--- a/src/domain/app/header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/domain/app/header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -213,7 +213,7 @@ exports[`Header matches snapshot 1`] = `
                     <span
                       class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
                     >
-                      Helsinki Profiili
+                      Helsinki-profiili
                     </span>
                   </button>
                   <button

--- a/src/domain/app/header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/domain/app/header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -196,6 +196,36 @@ exports[`Header matches snapshot 1`] = `
                     >
                       <svg
                         aria-hidden="true"
+                        aria-label="link-external"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Helsinki Profiili
+                    </span>
+                  </button>
+                  <button
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV dropdownButton"
+                    type="button"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
                         aria-label="signout"
                         class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
                         role="img"

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -703,7 +703,8 @@
     "userMenu": {
       "ariaLabelButton": "Open user menu",
       "logout": "Log out",
-      "openMyProfile": "My profile"
+      "openMyProfile": "My profile",
+      "openHelsinkiProfile": "Helsinki Profile"
     }
   },
   "image": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -709,7 +709,7 @@
       "ariaLabelButton": "Avaa käyttäjän valikko",
       "logout": "Kirjaudu ulos",
       "openMyProfile": "Omat tiedot",
-      "openHelsinkiProfile": "Helsinki Profiili"
+      "openHelsinkiProfile": "Helsinki-profiili"
     }
   },
   "image": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -708,7 +708,8 @@
     "userMenu": {
       "ariaLabelButton": "Avaa käyttäjän valikko",
       "logout": "Kirjaudu ulos",
-      "openMyProfile": "Omat tiedot"
+      "openMyProfile": "Omat tiedot",
+      "openHelsinkiProfile": "Helsinki Profiili"
     }
   },
   "image": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -711,7 +711,7 @@
       "ariaLabelButton": "Öppna användarmenyn",
       "logout": "Logga ut",
       "openMyProfile": "Min profil",
-      "openHelsinkiProfile": "Helsingfors Profil"
+      "openHelsinkiProfile": "Helsingforsprofilen"
     }
   },
   "image": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -710,7 +710,8 @@
     "userMenu": {
       "ariaLabelButton": "Öppna användarmenyn",
       "logout": "Logga ut",
-      "openMyProfile": "Min profil"
+      "openMyProfile": "Min profil",
+      "openHelsinkiProfile": "Helsingfors Profil"
     }
   },
   "image": {

--- a/src/domain/app/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/domain/app/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`PageLayout matches snapshot 1`] = `
                       <span
                         class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
                       >
-                        Helsinki Profiili
+                        Helsinki-profiili
                       </span>
                     </button>
                     <button

--- a/src/domain/app/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/domain/app/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
@@ -199,6 +199,36 @@ exports[`PageLayout matches snapshot 1`] = `
                       >
                         <svg
                           aria-hidden="true"
+                          aria-label="link-external"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Helsinki Profiili
+                      </span>
+                    </button>
+                    <button
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV dropdownButton"
+                      type="button"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
                           aria-label="signout"
                           class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
                           role="img"


### PR DESCRIPTION
## Description :sparkles:
Adds Helsinki profile link to the user menu
NOTE: external link icon is placed on the left, so all the links look the same.

## Issues :bug:

### Closes :no_good_woman:

**[PT-1777](https://helsinkisolutionoffice.atlassian.net/browse/PT-1777):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[PT-1777]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ