### PR TITLE
fix: idle timer provider

### DIFF
--- a/src/domain/auth/IdleTimerProvider.tsx
+++ b/src/domain/auth/IdleTimerProvider.tsx
@@ -9,8 +9,13 @@ type IdleTimerProps = { children: React.ReactNode };
 function IdleTimer({ children }: IdleTimerProps) {
   const { logout, isAuthenticated } = useOidcClient();
   const onIdle = (): void => {
-    if (isAuthenticated()) {
-      logout();
+    try {
+      if (isAuthenticated()) {
+        logout();
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error('useOidcClient is fully loaded yet.', { error: e });
     }
   };
 


### PR DESCRIPTION
Fixes the unit test issue in #363  .

PT-1807.

The onIdle was executed too fast when running the unit tests. The logout from the useOidcClient was not yet initialized, but the onIdle action was already called, so the function failed to execute.
