### PR TITLE
PT-1910 | Fix Dart Sass 3.0.0 deprecation warnings

### DIFF
--- a/src/common/components/autoSuggest/autoSuggest.module.scss
+++ b/src/common/components/autoSuggest/autoSuggest.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/fonts';
+@use '~styles/fonts';
 
 .a11yText {
   z-index: 9999;
@@ -88,7 +88,7 @@
 
   .infoMessage {
     padding: 1rem;
-    font-size: $font-size-lg;
+    font-size: fonts.$font-size-lg;
     text-align: center;
   }
 
@@ -102,7 +102,7 @@
 
   .listItem {
     padding: 1rem;
-    font-size: $font-size-lg;
+    font-size: fonts.$font-size-lg;
     display: grid;
     cursor: pointer;
     grid-template-columns: 1fr auto;

--- a/src/common/components/modal/modal.module.scss
+++ b/src/common/components/modal/modal.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/layout';
+@use '~styles/layout';
 
 .bodyOpen {
   overflow: hidden;
@@ -47,7 +47,7 @@
   padding: var(--spacing-modal);
   outline: none;
 
-  @include respond-below(l-plus) {
+  @include layout.respond-below(l-plus) {
     position: fixed;
     top: 0;
     left: 0;
@@ -55,7 +55,7 @@
     bottom: 0;
   }
 
-  @include respond-above(l-plus) {
+  @include layout.respond-above(l-plus) {
     width: var(--width-modal);
   }
 }

--- a/src/common/components/textEditor/textEditor.module.scss
+++ b/src/common/components/textEditor/textEditor.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .textEditor {
   --text-editor-border-width: 2px;

--- a/src/domain/app/footer/footer.module.scss
+++ b/src/domain/app/footer/footer.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .footer {
   display: grid;

--- a/src/domain/app/header/header.module.scss
+++ b/src/domain/app/header/header.module.scss
@@ -1,7 +1,7 @@
 // WORKAROUND: Marked all styles !important so they apply even if CSS order varies.
 //             Switching from CRA/Craco to Vite might remove the need for this hack.
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 @mixin active {
   color: var(--color-white) !important;
@@ -13,7 +13,7 @@
 }
 
 .dropdownButton {
-  min-width: $breakpoint-xs !important;
+  min-width: layout.$breakpoint-xs !important;
   text-align: left !important;
   justify-content: left !important;
   max-height: 40px !important;

--- a/src/domain/app/layout/container.module.scss
+++ b/src/domain/app/layout/container.module.scss
@@ -1,20 +1,20 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .container {
   display: grid;
   grid-row: span;
-  padding: $basePadding 0;
+  padding: variables.$basePadding 0;
   place-content: flex-start;
 
   grid-template-columns: 0.75rem 1fr 0.75rem;
 
-  @include respond-between(m, xxl) {
+  @include layout.respond-between(m, xxl) {
     grid-template-columns: 1fr 10fr 1fr;
   }
 
-  @include respond-above(xxl) {
-    grid-template-columns: 1fr minmax(auto, $containerMaxWidth) 1fr;
+  @include layout.respond-above(xxl) {
+    grid-template-columns: 1fr minmax(auto, variables.$containerMaxWidth) 1fr;
   }
 
   & > * {
@@ -22,14 +22,14 @@
   }
 
   &.xsmall {
-    @include respond-above(m) {
-      grid-template-columns: 1fr minmax(auto, $containerXSmallMaxWidth) 1fr;
+    @include layout.respond-above(m) {
+      grid-template-columns: 1fr minmax(auto, variables.$containerXSmallMaxWidth) 1fr;
     }
   }
 
   &.small {
-    @include respond-above(m) {
-      grid-template-columns: 1fr minmax(auto, $containerSmallMaxWidth) 1fr;
+    @include layout.respond-above(m) {
+      grid-template-columns: 1fr minmax(auto, variables.$containerSmallMaxWidth) 1fr;
     }
   }
 }

--- a/src/domain/app/layout/pageLayout.module.scss
+++ b/src/domain/app/layout/pageLayout.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/layout';
+@use '~styles/layout';
 
 .pageLayout {
   --background-color-body: #f7f6f6;
@@ -17,7 +17,7 @@
   display: grid;
   background-color: var(--background-color-body);
 
-  @include respond-below(m) {
+  @include layout.respond-below(m) {
     opacity: 1;
     transition:
       visibility 0.2s,

--- a/src/domain/enrolment/enrolmentForm/enrolmentForm.module.scss
+++ b/src/domain/enrolment/enrolmentForm/enrolmentForm.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/layout';
+@use '~styles/layout';
 
 .enrolmentForm {
   background-color: var(--color-black-10);
@@ -9,7 +9,7 @@
     display: grid;
     grid-gap: var(--spacing-layout-s);
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: 1fr 1fr;
     }
   }
@@ -18,7 +18,7 @@
     display: grid;
     grid-gap: var(--spacing-layout-s);
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: 1fr 1fr 1fr;
     }
   }

--- a/src/domain/errorPage/ErrorPage.module.scss
+++ b/src/domain/errorPage/ErrorPage.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/variables';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 .container {
   --header-fontsize: var(--fontsize-heading-l);
@@ -35,7 +35,7 @@
     width: 300px;
     margin-top: var(--content-spacing);
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       margin-top: 4rem;
     }
   }

--- a/src/domain/event/eventBasicInfo/eventBasicInfo.module.scss
+++ b/src/domain/event/eventBasicInfo/eventBasicInfo.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/layout';
+@use '~styles/layout';
 
 .eventBasicInfo {
   --grid-gap: var(--spacing-xl);
@@ -11,7 +11,7 @@
     display: grid;
     grid-gap: var(--grid-gap);
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: 1fr 1.5fr 1.5fr;
     }
   }

--- a/src/domain/event/eventCard/eventCard.module.scss
+++ b/src/domain/event/eventCard/eventCard.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .eventCard {
   --background-color-event-card: var(--color-white);
@@ -32,7 +32,7 @@
     outline: 2px var(--color-coat-of-arms) solid;
   }
 
-  @include respond_above(m) {
+  @include layout.respond-above(m) {
     grid-template-columns: var(--width-image) 1fr;
   }
 
@@ -42,13 +42,13 @@
     background-size: cover;
     background-repeat: no-repeat;
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       min-height: var(--height-image);
     }
   }
 
   .contentWrapper {
-    padding: $basePadding;
+    padding: variables.$basePadding;
     display: grid;
     grid-template-rows: 1fr auto;
   }

--- a/src/domain/event/eventCategorisation/eventCategorisation.module.scss
+++ b/src/domain/event/eventCategorisation/eventCategorisation.module.scss
@@ -1,11 +1,11 @@
-@import '~styles/layout';
+@use '~styles/layout';
 
 .eventCategorisation {
   .infoRow {
     display: grid;
     grid-gap: var(--grid-gap);
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: 1fr 1fr;
     }
   }

--- a/src/domain/event/eventDetailsButtons/eventDetailsButtons.module.scss
+++ b/src/domain/event/eventDetailsButtons/eventDetailsButtons.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/layout';
+@use '~styles/layout';
 .eventDetailsButtons {
   --grid-gap: var(--spacing-l);
 }
@@ -7,7 +7,7 @@
   grid-gap: var(--grid-gap);
   align-items: center;
 
-  @include respond_above(m) {
+  @include layout.respond-above(m) {
     grid-template-columns: 1fr auto auto;
   }
 }

--- a/src/domain/event/eventDetailsPage.module.scss
+++ b/src/domain/event/eventDetailsPage.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .eventDetailsPage {
   --color-delete-icon: var(--color-error);
@@ -16,7 +16,7 @@
 }
 
 .eventDetailsPage {
-  padding-bottom: $paddingBottomPage;
+  padding-bottom: variables.$paddingBottomPage;
 
   h1 {
     font-size: var(--fontsize-heading-l);
@@ -38,7 +38,7 @@
     display: grid;
     grid-gap: var(--grid-gap);
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: 2fr 1fr;
     }
   }

--- a/src/domain/event/eventForm/eventForm.module.scss
+++ b/src/domain/event/eventForm/eventForm.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .eventForm {
   --fontsize-header: var(--fontsize-heading-s);
@@ -35,7 +35,7 @@
     }
   }
 
-  @include respond_above(m) {
+  @include layout.respond-above(m) {
     grid-template-columns: 5fr 2fr;
   }
 
@@ -48,7 +48,7 @@
     display: grid;
     grid-gap: 20px;
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: 1fr 1fr;
     }
   }
@@ -57,7 +57,7 @@
     display: grid;
     grid-gap: var(--grid-gap);
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: 3fr 1fr;
     }
   }
@@ -71,7 +71,7 @@
     grid-gap: var(--grid-gap);
     margin-bottom: var(--spacing-m);
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: 1fr 3fr;
     }
   }
@@ -81,12 +81,12 @@
     grid-gap: var(--grid-gap);
     margin-bottom: var(--spacing-m);
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: 1fr 2fr 1fr;
     }
 
     .isFreeWrapper {
-      @include respond_above(m) {
+      @include layout.respond-above(m) {
         display: flex;
         align-self: end;
         margin-bottom: 1px;
@@ -102,7 +102,7 @@
     display: grid;
     grid-gap: var(--grid-gap);
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: 180px 1fr;
     }
 
@@ -120,9 +120,9 @@
 .occurrenceFormRow {
   display: grid;
 
-  @include respond_above(l-plus) {
+  @include layout.respond-above(l-plus) {
     grid-template-columns: 1fr 1fr 1fr 1fr;
-    grid-gap: $baseMargin;
+    grid-gap: variables.$baseMargin;
   }
 }
 

--- a/src/domain/event/eventImage/eventImage.module.scss
+++ b/src/domain/event/eventImage/eventImage.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .imageContainer {
   --photographer-background-color: rgba(255, 255, 255, 0.4);

--- a/src/domain/event/eventPage.module.scss
+++ b/src/domain/event/eventPage.module.scss
@@ -1,7 +1,7 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .eventPage {
-  padding-bottom: $paddingBottomPage;
+  padding-bottom: variables.$paddingBottomPage;
 
   h1 {
     font-size: var(--fontsize-heading-l);

--- a/src/domain/event/eventPreviewBasicInfo/eventPreviewBasicInfo.module.scss
+++ b/src/domain/event/eventPreviewBasicInfo/eventPreviewBasicInfo.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .eventBasicInfo {
   --inforow-spacing: var(--spacing-m);

--- a/src/domain/event/eventPreviewCard/eventPreviewCard.module.scss
+++ b/src/domain/event/eventPreviewCard/eventPreviewCard.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .eventCard {
   --background-color-event-card: var(--color-white);
@@ -35,7 +35,7 @@
   text-decoration: none;
   color: black;
 
-  @include respond_above(m) {
+  @include layout.respond-above(m) {
     grid-template-columns: var(--width-image) 1fr;
   }
 
@@ -45,7 +45,7 @@
     background-size: cover;
     background-repeat: no-repeat;
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       min-height: var(--height-image);
     }
   }
@@ -75,7 +75,7 @@
     grid-gap: var(--spacing-m);
     margin-top: var(--spacing-m);
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: 1fr 1fr;
     }
   }

--- a/src/domain/event/eventPublish/eventPublish.module.scss
+++ b/src/domain/event/eventPublish/eventPublish.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .publishSection {
   display: flex;

--- a/src/domain/event/eventSummaryPage.module.scss
+++ b/src/domain/event/eventSummaryPage.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .eventSummaryPage {
   --color-link: var(--color-bus);
@@ -13,7 +13,7 @@
 }
 
 .eventSummaryPage {
-  padding-bottom: $paddingBottomPage;
+  padding-bottom: variables.$paddingBottomPage;
 
   h1 {
     font-size: var(--fontsize-heading-l);

--- a/src/domain/events/eventsCategoryList/eventsCategoryList.module.scss
+++ b/src/domain/events/eventsCategoryList/eventsCategoryList.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .eventsContainer {
   display: grid;

--- a/src/domain/events/eventsPage.module.scss
+++ b/src/domain/events/eventsPage.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .eventsPage {
   --color-show-more-button: var(--color-bus);
@@ -11,7 +11,7 @@
 }
 
 .eventsPage {
-  padding-bottom: $paddingBottomPage;
+  padding-bottom: variables.$paddingBottomPage;
 
   h1 {
     font-size: var(--fontsize-heading-l);
@@ -25,11 +25,11 @@
   .comingEventsTitleWrapper {
     display: grid;
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: 1fr auto;
     }
 
-    @include respond_below(m) {
+    @include layout.respond-below(m) {
       h2 {
         order: 1;
       }
@@ -40,7 +40,7 @@
     display: grid;
     grid-gap: var(--grid-gap);
 
-    @include respond_above(m) {
+    @include layout.respond-above(m) {
       grid-template-columns: var(--width-input) 1fr auto;
     }
   }

--- a/src/domain/myProfile/myProfile.module.scss
+++ b/src/domain/myProfile/myProfile.module.scss
@@ -1,7 +1,7 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .myProfile {
-  padding-bottom: $paddingBottomPage;
+  padding-bottom: variables.$paddingBottomPage;
 
   h1 {
     font-size: var(--fontsize-heading-l);

--- a/src/domain/occurrence/enrolmentDetails/enrolmentDetails.module.scss
+++ b/src/domain/occurrence/enrolmentDetails/enrolmentDetails.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .enrolmentDetails {
   display: grid;

--- a/src/domain/occurrence/enrolmentTable/enrolmentModals/enrolmentModals.module.scss
+++ b/src/domain/occurrence/enrolmentTable/enrolmentModals/enrolmentModals.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/layout';
+@use '~styles/layout';
 
 .bodyOpen {
   overflow: hidden;
@@ -38,7 +38,7 @@
   top: var(--modal-top-padding);
   margin-bottom: var(--modal-top-padding);
 
-  @include respond-below(l-plus) {
+  @include layout.respond-below(l-plus) {
     position: fixed;
     top: 0;
     left: 0;
@@ -46,7 +46,7 @@
     bottom: 0;
   }
 
-  @include respond-above(l-plus) {
+  @include layout.respond-above(l-plus) {
     width: var(--width-modal);
   }
 }

--- a/src/domain/occurrence/occurrenceInfo/occurrenceInfo.module.scss
+++ b/src/domain/occurrence/occurrenceInfo/occurrenceInfo.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .occurrenceInfo {
   --width-icon: 1.5rem;

--- a/src/domain/occurrence/occurrencePage.module.scss
+++ b/src/domain/occurrence/occurrencePage.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .eventOccurrencePage {
   --color-link: var(--color-bus);
@@ -19,7 +19,7 @@
 }
 
 .eventOccurrencePage {
-  padding-bottom: $paddingBottomPage;
+  padding-bottom: variables.$paddingBottomPage;
 
   h1 {
     font-size: var(--fontsize-heading-l);

--- a/src/domain/occurrence/occurrencesFormPart/occurrencesFormPart.module.scss
+++ b/src/domain/occurrence/occurrencesFormPart/occurrencesFormPart.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .occurrencesFormPart {
   h2 {
@@ -20,7 +20,7 @@
   grid-gap: var(--grid-gap);
   margin-bottom: var(--spacing-l);
 
-  @include respond_above(l-plus) {
+  @include layout.respond-above(l-plus) {
     grid-template-columns: 1fr var(--date-column-width) 100px 180px repeat(
         3,
         100px
@@ -28,7 +28,7 @@
   }
 
   &Multiday {
-    @include respond_above(l-plus) {
+    @include layout.respond-above(l-plus) {
       grid-template-columns:
         1fr var(--date-column-width) calc(280px + var(--grid-gap))
         repeat(3, 100px);
@@ -40,7 +40,7 @@
   display: grid;
   grid-gap: var(--grid-gap);
 
-  @include respond_above(l-plus) {
+  @include layout.respond-above(l-plus) {
     grid-template-columns: 170px 100px;
   }
 }

--- a/src/domain/place/placeInfo/placeInfo.module.scss
+++ b/src/domain/place/placeInfo/placeInfo.module.scss
@@ -1,8 +1,8 @@
-@import '~styles/fonts';
+@use '~styles/fonts';
 
 .placeInfo {
   color: var(--color-black-90);
-  font-size: $body-medium-font-size;
+  font-size: fonts.$body-medium-font-size;
   line-height: 2rem;
 
   p {

--- a/src/domain/venue/venueDataFields/venueDataFields.module.scss
+++ b/src/domain/venue/venueDataFields/venueDataFields.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/layout';
+@use '~styles/layout';
 
 .venueCheckboxFields {
   display: flex;

--- a/src/headless-cms/components/cmsPage.module.scss
+++ b/src/headless-cms/components/cmsPage.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/layout';
+@use '~styles/layout';
 
 .container {
   padding: 0 !important;
@@ -63,19 +63,19 @@
     margin: 0;
   }
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     flex-direction: row;
   }
 
   &Main {
-    @include respond-above(m) {
+    @include layout.respond-above(m) {
       flex-basis: 66.666%;
       margin-right: var(--spacing-xs);
     }
   }
 
   &Aside {
-    @include respond-above(m) {
+    @include layout.respond-above(m) {
       flex-basis: 33.333%;
       margin-left: var(--spacing-xs);
     }

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -1,21 +1,23 @@
-@import '~hds-design-tokens/lib/breakpoint/all.scss';
+@use "sass:map";
+@use '~hds-design-tokens/lib/breakpoint/all.scss' as hds;
+@forward '~hds-design-tokens/lib/breakpoint/all.scss';
 
 //
 //  MEDIA QUERIES
 //––––––––––––––––––––––––––––––––––––––––––––––––––
 
 // Custom breakpoints for backward (i.e. pre HDS v3.5 upgrade) layout compatibility
-$custom-breakpoint-l-plus: $breakpoint-l + 32px; // 1024px
-$custom-breakpoint-xxl: $breakpoint-xl + $breakpoint-xs + 32px; // 1600px
+$custom-breakpoint-l-plus: hds.$breakpoint-l + 32px; // 1024px
+$custom-breakpoint-xxl: hds.$breakpoint-xl + hds.$breakpoint-xs + 32px; // 1600px
 
 // A map of breakpoints.
 $breakpoints: (
-  xs: $breakpoint-xs,
-  s: $breakpoint-s,
-  m: $breakpoint-m,
-  l: $breakpoint-l,
+  xs: hds.$breakpoint-xs,
+  s: hds.$breakpoint-s,
+  m: hds.$breakpoint-m,
+  l: hds.$breakpoint-l,
   l-plus: $custom-breakpoint-l-plus,
-  xl: $breakpoint-xl,
+  xl: hds.$breakpoint-xl,
   xxl: $custom-breakpoint-xxl,
 );
 
@@ -23,12 +25,12 @@ $breakpoints: (
 //  RESPOND ABOVE
 //––––––––––––––––––––––––––––––––––––––––––––––––––
 
-// @include respond-above(m) {}
+// @include layout.respond-above(m) {}
 @mixin respond-above($breakpoint) {
   // If the breakpoint exists in the map.
-  @if map-has-key($breakpoints, $breakpoint) {
+  @if map.has-key($breakpoints, $breakpoint) {
     // Get the breakpoint value.
-    $breakpoint-value: map-get($breakpoints, $breakpoint);
+    $breakpoint-value: map.get($breakpoints, $breakpoint);
 
     // Write the media query.
     @media (min-width: $breakpoint-value) {
@@ -46,12 +48,12 @@ $breakpoints: (
 //  RESPOND BELOW
 //––––––––––––––––––––––––––––––––––––––––––––––––––
 
-// @include respond-below(m) {}
+// @include layout.respond-below(m) {}
 @mixin respond-below($breakpoint) {
   // If the breakpoint exists in the map.
-  @if map-has-key($breakpoints, $breakpoint) {
+  @if map.has-key($breakpoints, $breakpoint) {
     // Get the breakpoint value.
-    $breakpoint-value: map-get($breakpoints, $breakpoint);
+    $breakpoint-value: map.get($breakpoints, $breakpoint);
 
     // Write the media query.
     @media (max-width: ($breakpoint-value - 1)) {
@@ -69,13 +71,13 @@ $breakpoints: (
 //  RESPOND BETWEEN
 //––––––––––––––––––––––––––––––––––––––––––––––––––
 
-// @include respond-between(m, l-plus) {}
+// @include layout.respond-between(m, l-plus) {}
 @mixin respond-between($lower, $upper) {
   // If both the lower and upper breakpoints exist in the map.
-  @if map-has-key($breakpoints, $lower) and map-has-key($breakpoints, $upper) {
+  @if map.has-key($breakpoints, $lower) and map.has-key($breakpoints, $upper) {
     // Get the lower and upper breakpoints.
-    $lower-breakpoint: map-get($breakpoints, $lower);
-    $upper-breakpoint: map-get($breakpoints, $upper);
+    $lower-breakpoint: map.get($breakpoints, $lower);
+    $upper-breakpoint: map.get($breakpoints, $upper);
 
     // Write the media query.
     @media (min-width: $lower-breakpoint) and (max-width: ($upper-breakpoint - 1)) {
@@ -85,13 +87,13 @@ $breakpoints: (
     // If one or both of the breakpoints don't exist.
   } @else {
     // If lower breakpoint is invalid.
-    @if (map-has-key($breakpoints, $lower) == false) {
+    @if (map.has-key($breakpoints, $lower) == false) {
       // Log a warning.
       @warn 'Your lower breakpoint was invalid: #{$lower}.';
     }
 
     // If upper breakpoint is invalid.
-    @if (map-has-key($breakpoints, $upper) == false) {
+    @if (map.has-key($breakpoints, $upper) == false) {
       // Log a warning.
       @warn 'Your upper breakpoint was invalid: #{$upper}.';
     }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,7 +1,7 @@
-@import '~styles/vendor/normalize';
-@import '~styles/fonts';
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/vendor/normalize';
+@use '~styles/fonts';
+@use '~styles/layout';
+@use '~styles/variables';
 
 html {
   height: 100%;
@@ -43,5 +43,5 @@ button {
 
 // Override globally all text to use Helsinki font.
 * {
-  font-family: $font-family-base;
+  font-family: fonts.$font-family-base;
 }


### PR DESCRIPTION
## Description :sparkles:

Make SCSS files Dart Sass 3.0.0 compatible.

Main changes:
 - use @use instead of @import and prefix variable uses with module
   name, e.g. fonts.$font-size instead of $font-size
 - use sass:map + map.get + map.has-key

see https://sass-lang.com/documentation/breaking-changes/import/

### Building after code changes in this PR

No deprecation warnings are shown:
```
$ yarn build
yarn run v1.22.22
$ tsc && vite build
vite v6.2.5 building for production...
✓ 3162 modules transformed.
build/index.html                                   2.30 kB │ gzip:   0.96 kB
build/assets/event_placeholder_B-BzLh8f4A.jpg     34.57 kB
build/assets/event_placeholder_A-DYj7CDCc.jpg     44.88 kB
build/assets/event_placeholder_D-D0MxpYca.jpg     50.54 kB
build/assets/event_placeholder_C-DHhvI6N5.jpg     56.75 kB
build/assets/index-PJcKlXUy.css                  103.20 kB │ gzip:  16.37 kB
build/assets/index-DFIkSxfX.js                 2,896.39 kB │ gzip: 833.17 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 27.71s
Done in 37.14s.
```

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[PT-1910](https://helsinkisolutionoffice.atlassian.net/browse/PT-1910)

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[PT-1910]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ