### PR TITLE
fix: flex-wrap footer links when they do not fit in single row

### DIFF
--- a/src/domain/app/footer/Footer.tsx
+++ b/src/domain/app/footer/Footer.tsx
@@ -48,6 +48,7 @@ const Footer: FunctionComponent = () => {
         }
         backToTopLabel={t('footer.backToTop')}
         onBackToTopClick={handleBackToTop}
+        className={styles.footerBase}
       >
         {footerLinks.map((footerLink) => (
           <HDSFooter.Link

--- a/src/domain/app/footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/domain/app/footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`Footer matches snapshot 1`] = `
         Kultus Admin
       </h2>
       <div
-        class="FooterBase-module_base__2f0eu"
+        class="FooterBase-module_base__2f0eu footerBase"
       >
         <hr
           aria-hidden="true"

--- a/src/domain/app/footer/footer.module.scss
+++ b/src/domain/app/footer/footer.module.scss
@@ -5,3 +5,7 @@
   margin-top: calc(var(--spacing-xl) * -1);
   --footer-background: var(--color-black-10) !important;
 }
+
+.footerBase div[class^='FooterBase-module_links'] {
+  flex-wrap: wrap;
+}

--- a/src/domain/app/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/domain/app/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
@@ -634,7 +634,7 @@ exports[`PageLayout matches snapshot 1`] = `
           Kultus Admin
         </h2>
         <div
-          class="FooterBase-module_base__2f0eu"
+          class="FooterBase-module_base__2f0eu footerBase"
         >
           <hr
             aria-hidden="true"


### PR DESCRIPTION
PT-1916

Sometimes the footer links does not fit in a single row, so they should be wrapped to the next line.

NOTE: Similar fix in [palvelutarjotin-ui](https://github.com/City-of-Helsinki/palvelutarjotin-ui/pull/393).