### PR TITLE
fix: occurrences deletion UI update on event creation page

### DIFF
--- a/src/domain/occurrence/CreateOccurrencePage.tsx
+++ b/src/domain/occurrence/CreateOccurrencePage.tsx
@@ -265,6 +265,7 @@ const CreateOccurrencePage: React.FC = () => {
     skip: !eventId,
     variables: { id: eventId! },
     fetchPolicy: 'network-only',
+    nextFetchPolicy: 'cache-and-network',
   });
 
   // Get access to latest eventData in handleGoToPublishingClick when it is called

--- a/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
+++ b/src/domain/occurrence/occurrencesFormPart/OccurrencesFormPart.tsx
@@ -464,6 +464,7 @@ const OccurrencesForm: React.FC<{
             });
           },
         });
+        toast.success(t('occurrences.deleteSuccess'));
       } catch (error) {
         toast.error(t('occurrences.deleteError'));
         // eslint-disable-next-line no-console


### PR DESCRIPTION
PT-1683.

Deleting occurrences from event creation page's occurrences table did not update the table. Instead the deleted occurrence still persisted in the table. No notification was shown.

The occurrences table got it's data from event query which was fetched in CreateOccurrencePage. That query was using network only as a fetchPolicy, but the update of the deletion was done by updating the cache. Because of that, the query never saw the deletion and the UI did not get updated.

<img width="1129" alt="image" src="https://github.com/user-attachments/assets/866674db-eb8e-4e86-8d84-79d536981ad4" />
