### PR TITLE
fix: remove process.env from vite config define

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,9 +11,6 @@ const viteConfig = ({ mode }) => {
   process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
 
   return defineConfig({
-    define: {
-      'process.env': process.env,
-    },
     resolve: {
       alias: {
         '~hds-core': path.resolve(__dirname, './node_modules/hds-core'),


### PR DESCRIPTION
PT-1927.

The `process.env` is not used anywhere, (except in Playwright).

Fixes the warning in startup saying:

```
$ vite preview
The `define` option contains an object with "PATH" for "process.env"
key.
It looks like you may have passed the entire `process.env` object to
`define`,
which can unintentionally expose all environment variables.
This poses a security risk and is discouraged.
```
