### PR TITLE
KEH-281 | Pin vulnerable transitive dependencies for security fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,12 @@
         "To force patched underscore for doctoc transitive dependency",
         "See https://www.npmjs.com/advisories/1113950",
         "NOTE: This can be removed when doctoc no longer resolves underscore <1.13.8"
+      ],
+      "tmp": [
+        "tmp allows arbitrary temporary file/directory write via symbolic link in versions <0.2.4",
+        "Pinning to >=0.2.4 via @graphql-codegen/cli > inquirer > external-editor > tmp",
+        "See https://www.npmjs.com/advisories/1109537",
+        "NOTE: This can be removed when @graphql-codegen/cli no longer resolves vulnerable tmp versions"
       ]
     }
   },
@@ -103,7 +109,8 @@
     "hds-react/cookie": "^0.7.2",
     "lodash": "^4.18.1",
     "minimatch": ">=9.0.7",
-    "doctoc/underscore": "^1.13.8"
+    "doctoc/underscore": "^1.13.8",
+    "tmp": ">=0.2.4"
   },
   "dependencies": {
     "@apollo/client": "^3.13.8",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
         "That's why @testing-library/dom has been added to resolutions.",
         "NOTE: This can be removed after dependencies don't bring conflicting/old versions"
       ],
+      "@tootallnate/once": [
+        "@tootallnate/once vulnerable to Incorrect Control Flow Scoping in versions <3.0.1",
+        "Pinning to >=3.0.1 via react-helsinki-headless-cms > jest-environment-jsdom > jsdom > http-proxy-agent > @tootallnate/once",
+        "See https://www.npmjs.com/advisories/1113977",
+        "NOTE: This can be removed when react-helsinki-headless-cms no longer resolves vulnerable @tootallnate/once versions"
+      ],
       "@types/cookie": [
         "To use the last known @types/cookie version, only for <v1 cookie",
         "",
@@ -95,6 +101,7 @@
   },
   "resolutions": {
     "@testing-library/dom": "^10.4.0",
+    "@tootallnate/once": ">=3.0.1",
     "@types/cookie": "^0.6.0",
     "draft-js/immutable": "3.8.3",
     "**/@ardatan/relay-compiler/immutable": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "engines": {
     "node": ">=22.13.1"
   },
+  "packageManager": "yarn@1.22.22",
   "//": {
     "Why are packages in resolutions?": {
       "@testing-library/dom": [
@@ -74,6 +75,11 @@
         "in versions <9.0.7. Pinning to >=9.0.7 fixes all three issues.",
         "NOTE: This can be removed when hds-react updates @typescript-eslint/parser to use minimatch >=9.0.7"
       ],
+      "lodash": [
+        "To fix GHSA-f23m-r3pf-42rh and GHSA-r5fr-rjxr-66jc",
+        "Pinning lodash to >=4.18.1 fixes prototype pollution vulnerabilities",
+        "NOTE: This can be removed when all transitive dependencies use patched lodash versions"
+      ],
       "doctoc/underscore": [
         "To force patched underscore for doctoc transitive dependency",
         "See https://www.npmjs.com/advisories/1113950",
@@ -95,6 +101,7 @@
     "globals": "^16.0.0",
     "hds-react/@babel/runtime": "^7.27.0",
     "hds-react/cookie": "^0.7.2",
+    "lodash": "^4.18.1",
     "minimatch": ">=9.0.7",
     "doctoc/underscore": "^1.13.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6441,10 +6441,10 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+lodash@^4.17.20, lodash@^4.17.21, lodash@^4.18.1, lodash@~4.17.0:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.0.0, log-symbols@^4.1.0:
   version "4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7038,11 +7038,6 @@ ora@^5.4.1:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
-
 outvariant@^1.4.0, outvariant@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
@@ -8410,12 +8405,10 @@ tldts@^6.1.32:
   dependencies:
     tldts-core "^6.1.86"
 
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
+tmp@>=0.2.4, tmp@^0.0.33:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
+  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
 
 to-regex-range@^5.0.1:
   version "5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2191,10 +2191,10 @@
     traverse "^0.6.7"
     unified "^9.2.2"
 
-"@tootallnate/once@2":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
-  integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+"@tootallnate/once@2", "@tootallnate/once@>=3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-3.0.1.tgz#d580decb59cb41a15856387a86800838102daf44"
+  integrity sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==
 
 "@tybys/wasm-util@^0.10.0", "@tybys/wasm-util@^0.10.1":
   version "0.10.1"


### PR DESCRIPTION
## Summary
Pins three vulnerable transitive dependencies to safe versions using Yarn resolutions. All are indirect dependencies that cannot be updated directly.

| Package | Vulnerability | Safe version | Advisory |
|---|---|---|---|
| `lodash` | Prototype pollution (GHSA-f23m-r3pf-42rh, GHSA-r5fr-rjxr-66jc) | `>=4.18.1` | via various transitive deps |
| `tmp` | Arbitrary file/directory write via symlink | `>=0.2.4` | [#1109537](https://www.npmjs.com/advisories/1109537) via `@graphql-codegen/cli` |
| `@tootallnate/once` | Incorrect Control Flow Scoping | `>=3.0.1` | [#1113977](https://www.npmjs.com/advisories/1113977) via `react-helsinki-headless-cms` |

Also sets `packageManager` field to `yarn@1.22.22` to enforce the correct Yarn version.

Refs KEH-281