### PR TITLE
fix: resolve html-to-draftjs CJS/ESM interop error with Vite 8 PT-2037

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
                 frame-src 'self' *.hel.fi *.hel.ninja *.youtube.com www.youtube-nocookie.com *.vimeo.com;
                 img-src 'self' data: *.hel.fi *.hel.ninja *.ytimg.com *.youtube.com *.vimeo.com *.vimeocdn.com *.blob.core.windows.net *.hkih.hion.dev;
                 font-src 'self' *.hel.fi *.hel.ninja;
-                connect-src 'self' localhost:* 127.0.0.1:* *.hel.fi *.hel.ninja *.hkih.hion.dev *.digiaiiris.com;
+                connect-src 'self' localhost:* 127.0.0.1:* *.hel.fi *.hel.ninja *.hkih.hion.dev *.digiaiiris.com *.sentry.io;
                 manifest-src 'self';
                 base-uri 'self';
                 form-action 'self';

--- a/src/common/components/textEditor/TextEditor.tsx
+++ b/src/common/components/textEditor/TextEditor.tsx
@@ -14,7 +14,7 @@ import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 import classNames from 'classnames';
 import { ContentState, convertToRaw, EditorState } from 'draft-js';
 import draftToHtml from 'draftjs-to-html';
-import htmlToDraft from 'html-to-draftjs';
+import htmlToDraftImport from 'html-to-draftjs';
 import React from 'react';
 import { Editor, EditorState as EditorStateWysiwyg } from 'react-draft-wysiwyg';
 import { useTranslation } from 'react-i18next';
@@ -23,6 +23,13 @@ import { getTextEditorLocalization, toolbarOptions } from './constants';
 import styles from './textEditor.module.scss';
 import useIsMounted from '../../../hooks/useIsMounted';
 import InputWrapper, { InputWrapperProps } from '../inputWrapper/InputWrapper';
+
+// Vite 8 CJS/ESM interop: html-to-draftjs uses module.exports, unwrap .default if needed
+const htmlToDraft: typeof htmlToDraftImport =
+  typeof htmlToDraftImport === 'function'
+    ? htmlToDraftImport
+    : (htmlToDraftImport as unknown as { default: typeof htmlToDraftImport })
+        .default;
 
 const convertHtmlToEditorState = (html: string) => {
   const blocksFromHtml = htmlToDraft(html);


### PR DESCRIPTION
Refs: PT-2037

## Description :sparkles:


html-to-draftjs is a CJS module that, under Vite 8's updated ESM interop, may expose the converter function under .default rather than as the direct import. This caused a runtime crash (htmlToDraft is not a function) when opening the event form.

Added a small interop shim that checks whether the import is already a function and unwraps .default if not, making it safe under both old and new Vite behavior.

Also add sentry to connect-src. That was causing errors unrelated to this.

## Issues :bug:

### Closes :no_good_woman:

**[PT-2037](https://helsinkisolutionoffice.atlassian.net/browse/PT-2037):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[PT-2037]: https://helsinkisolutionoffice.atlassian.net/browse/PT-2037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ